### PR TITLE
board-image/buildroot-sdk-milkv-duo: Bump to 1.1.3-matrix.bot

### DIFF
--- a/manifests/board-image/1.1.3-matrix.bot.toml
+++ b/manifests/board-image/1.1.3-matrix.bot.toml
@@ -1,0 +1,25 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo-sd-v1.1.3-2024-0930.img.zip"
+size = 70646903
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.3/milkv-duo-sd-v1.1.3-2024-0930.img.zip",]
+
+[distfiles.checksums]
+sha256 = "48e3acf4a64a34f87cb1328c205c238a495ac5e9be3054516ca0748d0d77f05b"
+sha512 = "c7cf12defa5f006680ac30136624819a4c0d56724cd207aef0c0ce4d033aacbe705e0608dbfc04a7ee97671e24b03c2240d9bb16b0b587d9fd73bf8f6833119c"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duo-sd-v1.1.3-2024-0930.img.zip"
+
+[blob]
+distfiles = [ "milkv-duo-sd-v1.1.2-2024-0801.ruyi1.img.zst",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo-sd-v1.1.2-2024-0801.ruyi1.img"


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duo from 1.1.2-ruyi.20240914 to 1.1.3-matrix.bot.

Identifier: [HASH[d8b31139a3c0aa83b767fc7d554862cb49b30e0949fb32cb8203f38a]]

This PR is made by ruyi-index-updator bot.
