### PR TITLE
board-image/buildroot-sdk-milkv-duo: Bump to 1.1.3-matrix.bot

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo/1.1.3.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo/1.1.3.toml
@@ -1,0 +1,28 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo-sd-v1.1.3-2024-0930.img.zip"
+size = 70646903
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.3/milkv-duo-sd-v1.1.3-2024-0930.img.zip",]
+
+[distfiles.checksums]
+sha256 = "48e3acf4a64a34f87cb1328c205c238a495ac5e9be3054516ca0748d0d77f05b"
+sha512 = "c7cf12defa5f006680ac30136624819a4c0d56724cd207aef0c0ce4d033aacbe705e0608dbfc04a7ee97671e24b03c2240d9bb16b0b587d9fd73bf8f6833119c"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duo-sd-v1.1.3-2024-0930.img.zip"
+
+[blob]
+distfiles = [ "milkv-duo-sd-v1.1.3-2024-0930.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo-sd-v1.1.3-2024-0930.img"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duo from 1.1.2-ruyi.20240914 to 1.1.3-matrix.bot.

Identifier: [HASH[3b92635e78fd38fade35968fdb1dbf8e8044ca5c40fe30875d465ac4]]

This PR is made by ruyi-index-updator bot.