### PR TITLE
board-image/uboot-revyos-sipeed-lpi4a-8g: Bump to 0.20240720.0

### DIFF
--- a/manifests/board-image/0.20240720.0.toml
+++ b/manifests/board-image/0.20240720.0.toml
@@ -1,0 +1,25 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a.20240720.bin"
+size = 1032280
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20240720/u-boot-with-spl-lpi4a.bin",]
+
+[distfiles.checksums]
+sha256 = "d3d173513290289ac8a4c9ef2ec2943ca6e23f1eebbc806a13f6ced91c22b093"
+sha512 = "a732e09c7c3c8b508ad0da8ca4110bdae5a1c6e423ac4f93b0645c150a513fff0df0ed3a5352110563aa4c92b63d5746009c0ce777cf20fca84710edac42d730"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (8G RAM) and RevyOS 20240720"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a.20240720.bin",]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a.20240720.bin"


### PR DESCRIPTION
Bump uboot-revyos-sipeed-lpi4a-8g from 0.20240720.0 to 0.20240720.0.

Identifier: [HASH[d514bca6cd0c17f1555b9ac2ca6f9daddfaeb127746d4dd12bd30e30]]

This PR is made by ruyi-index-updator bot.
