### PR TITLE
board-image/buildroot-sdk-milkv-duos-sd: Bump to 1.1.3

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.3.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.3.toml
@@ -1,0 +1,28 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duos-sd-v1.1.3-2024-0930.img.zip"
+size = 70391226
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.3/milkv-duos-sd-v1.1.3-2024-0930.img.zip",]
+
+[distfiles.checksums]
+sha256 = "df8f970693fb101e6483cd80a54f0b7c0f4796e707b845abda96d96b7fea5ab0"
+sha512 = "85e9926d077afae9cbe160d833835c9f82d8029590495645b4b308a0d7ad3d626e7116980aaa3d03f2c083a122483180a88ca9dab7e0a93d89d9b506a99f9814"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duos-sd-v1.1.3-2024-0930.img.zip"
+
+[blob]
+distfiles = [ "milkv-duos-sd-v1.1.3-2024-0930.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duos-sd-v1.1.3-2024-0930.img"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duos-sd from 1.1.2-ruyi.20240914 to 1.1.3.

Identifier: [HASH[2ea26e16c85c2a63d1d4a59cf306c84ce5c6ca439fca368a5b7129eb]]

This PR is made by ruyi-index-updator bot.
