### PR TITLE
board-image/debian-fishwaldo-sg200x-sipeed-licheervnano: Bump to 1.4.0

### DIFF
--- a/manifests/board-image/debian-fishwaldo-sg200x-sipeed-licheervnano/1.4.0.toml
+++ b/manifests/board-image/debian-fishwaldo-sg200x-sipeed-licheervnano/1.4.0.toml
@@ -1,0 +1,28 @@
+format = "v1"
+[[distfiles]]
+name = "licheervnano_sd.img.lz4"
+size = 198977811
+urls = [ "https://github.com/Fishwaldo/sophgo-sg200x-debian/releases/download/v1.4.0/licheervnano_sd.img.lz4",]
+
+[distfiles.checksums]
+sha256 = "ca76556c7546f1424fd524b7edc83bc9d3f9255a4122535f75bac5ba85acd3bb"
+sha512 = "3f27c76b35aea2151b13c823e82a39d679bfa7e8e606f228cf78ca9b13c62ee4d00b34dfc52a7c6808cdc1f562986cbab62ca9b5ad551467e21586b0443467e2"
+
+[metadata]
+desc = "Debian image for Sipeed LicheeRV Nano with Sophgo SG200x, from https://github.com/Fishwaldo"
+
+[blob]
+distfiles = [ "licheervnano_sd.img.lz4",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "github:Fishwaldo"
+eula = ""
+
+[provisionable.partition_map]
+disk = "licheervnano_sd.img"
+
+# This file is created by program renew_ruyi_index in support-matrix
+# Run: In local


### PR DESCRIPTION
Bump debian-fishwaldo-sg200x-sipeed-licheervnano from 1.0.0 to 1.4.0.

Identifier: [HASH[ce5f428d2393fd82970688dd6171b72a9e15c7ccb996b27185a9751d]]

This PR is made by ruyi-index-updator bot.
