### PR TITLE
board-image/revyos-sipeed-lpi4a: Bump to 0.20241229.0

### DIFF
--- a/manifests/board-image/revyos-sipeed-lpi4a/0.20241229.0.toml
+++ b/manifests/board-image/revyos-sipeed-lpi4a/0.20241229.0.toml
@@ -1,0 +1,38 @@
+format = "v1"
+[[distfiles]]
+name = "root-lpi4a-20241229_032148.ext4.zst"
+size = 1332458168
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20241229/root-lpi4a-20241229_032148.ext4.zst",]
+
+[distfiles.checksums]
+sha256 = "f1bbf88fe44a8042a53235d0b02c830842b85b51d98d20e721b3e106f6587157"
+sha512 = "dc766ab6b492da7c2c187632157742a6ead5dea4334052b976af4c5f00926cc5be986683cb0938b0d28da72ae98882282a503e3707d047bf49806c19aad7c63e"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-main_8gemmc.bin"
+size = 1033904
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20241229/u-boot-with-spl-lpi4a-main_8gemmc.bin",]
+
+[distfiles.checksums]
+sha256 = "48ce29fe00933c82d3840142b659873fe37abb3a65574ad3d280408675922a38"
+sha512 = "f4a893597336f5de74fdf1a4e0f05e498e2f31ad9ea777ce3c224f7010309d7608c6eb21e6f8de3eda9901bffb4a5c8045cb0c83d07eea0863d48faa86d75da7"
+
+[metadata]
+desc = "RevyOS 20241229 image for Sipeed LicheePi 4A"
+
+[blob]
+distfiles = [ "root-lpi4a-20241229_032148.ext4.zst", "u-boot-with-spl-lpi4a-main_8gemmc.bin",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+boot = "u-boot-with-spl-lpi4a-main_8gemmc"
+root = "root-lpi4a-20241229_032148.ext4"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12655435394
+# Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/12655435394


### PR DESCRIPTION
Bump revyos-sipeed-lpi4a from 0.20240720.0 to 0.20241229.0.

Identifier: [HASH[6b6a149b0a4f10bca1b6004f383d3bb1251ee925a823d270b06d9389]]

This PR is made by ruyi-index-updator bot.
