### PR TITLE
board-image/buildroot-sdk-milkv-duo: Bump to 2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo/2.0.0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo/2.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo-musl-riscv64-sd_v2.0.0.img.zip"
+size = 63204048
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duo-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[distfiles.checksums]
+sha256 = "893d876be93e70079d9acaf0ea57704e470b2fb540616fd3d943615fccfd6369"
+sha512 = "18f25ecdf0b545534877e56c84d1b2b31c3e92aa801192fcd856c9ed743578c4e506b77b139f2895a833a5355386b025f7d9de506a5b86b788c31cd49a97e20a"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duo-musl-riscv64-sd_v2.0.0.img.zip"
+
+[blob]
+distfiles = [ "milkv-duo-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo-musl-riscv64-sd_v2.0.0.img"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12910390785
+# Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/12910390785


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duo from 1.1.3 to 2.0.0.

Identifier: [HASH[9bb46519a923d64476e1aabd4ba07592b5157c0c56b76cb4a65502cb]]

This PR is made by ruyi-index-updator bot.
