### PR TITLE
board-image/buildroot-sdk-milkv-duo256m: Bump to 2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo256m/2.0.0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo256m/2.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip"
+size = 63544801
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[distfiles.checksums]
+sha256 = "baaf8fc9e7de40c4dc2d7c6c9d5d8f16a3c871ce98c0c0451733ffdd7efc3fec"
+sha512 = "40987a69b22fc65c044ec911f328a5da82bc0a54c9f35d9e436210498a1f048204d66fdf5249f2cdd7a7a53bf635df82934cc8829df6b3ec91ae1c5608d64786"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip"
+
+[blob]
+distfiles = [ "milkv-duo256m-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duo256m-musl-riscv64-sd_v2.0.0.img"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12910390785
+# Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/12910390785


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duo256m from 1.1.2-ruyi.20240914 to 2.0.0.

Identifier: [HASH[6891ddf0efb06ccecc894bf7d32d401eafbc83a3d564e0fcd9a2266e]]

This PR is made by ruyi-index-updator bot.
