### PR TITLE
board-image/buildroot-sdk-milkv-duos-sd: Bump to 2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/2.0.0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/2.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+[[distfiles]]
+name = "milkv-duos-musl-riscv64-sd_v2.0.0.img.zip"
+size = 70543302
+urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duos-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[distfiles.checksums]
+sha256 = "04b88c4c43adeee2c7c266188d39c7bc3c54fdc1f1d317bded5a7afe6844a1e8"
+sha512 = "5f64d92c08b589af18505e71199e7b7e1e14dc6fe0ddb3800853caf85372765863dd25c29d8fb5eb799873241ac084f9231ea33bd2debefcb76e93ace381061e"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duos-musl-riscv64-sd_v2.0.0.img.zip"
+
+[blob]
+distfiles = [ "milkv-duos-musl-riscv64-sd_v2.0.0.img.zip",]
+
+[provisionable]
+strategy = "dd-v1"
+
+[metadata.vendor]
+name = "Milk-V"
+eula = ""
+
+[provisionable.partition_map]
+disk = "milkv-duos-musl-riscv64-sd_v2.0.0.img"
+
+# This file is created by CI Sync Package Index inside support-matrix
+# Run ID: 12910390785
+# Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/12910390785


### PR DESCRIPTION
Bump buildroot-sdk-milkv-duos-sd from 1.1.3 to 2.0.0.

Identifier: [HASH[8b5b34fe1a5dbf23c2a362bc00f8b29a82497c906e2354daed19a00f]]

This PR is made by ruyi-index-updator bot.
