### PR TITLE
Bump image ubuntu in device sifive-unmatched to version 24.10

### DIFF
--- a/manifests/board-image/ubuntu-sifive-unmatched/2410.0.0.toml
+++ b/manifests/board-image/ubuntu-sifive-unmatched/2410.0.0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img.xz"
+size = 1032701560
+urls = [ "https://mirror.iscas.ac.cn/ubuntu-cdimage/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img.xz",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "aff591c54a782f8068523fd8ffa4a2721c4959902b578778bb3cdcbec8934f28"
+sha512 = "308880616455b6006a2c50cebb21b1e6596f29acc51f9bccdb36eb964d468ec9a1fce4d2c00faac0cc1997ffb622bce57cc3990ac166b3f159a701efc34ccc98"
+
+[metadata]
+desc = "Official Ubuntu 24.10 Server image for SiFive HiFive Unmatched"
+service_level = []
+upstream_version = "24.10"
+
+[blob]
+distfiles = [ "ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img.xz",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "sifive-unmatched"
+eula = ""
+
+[provisionable.partition_map]
+disk = "ubuntu-24.10-preinstalled-server-riscv64%2Bunmatched.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14662502620
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14662502620

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -524,6 +524,10 @@ image_combos:
     display_name: buildroot SDK for LicheeRV Nano
     packages:
       - board-image/buildroot-sdk-sipeed-licheervnano
+  - id: ubuntu-sifive-unmatched
+    display_name: ubuntu  for HiFive Unmatched
+    packages:
+      - board-image/ubuntu-sifive-unmatched
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -671,6 +675,7 @@ devices:
           - openwrt-sifive-unmatched
           - ubuntu-server-sifive-unmatched
 
+          - ubuntu-sifive-unmatched
   - id: sipeed-lc4a
     display_name: "Sipeed Lichee Cluster 4A"
     variants:


### PR DESCRIPTION

Bump image ubuntu in device sifive-unmatched to version 24.10

Ident: 844eb098f53a26e8be70fc7ea18dfd175103f1055731fa069a354eb052b1228f

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14529631240
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14529631240
