### PR TITLE
Bump image revyos in device sipeed-lpi4a to version 20250323

### DIFF
--- a/manifests/board-image/revyos-sipeed-lpi4a/0.20250323.0.toml
+++ b/manifests/board-image/revyos-sipeed-lpi4a/0.20250323.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+[[distfiles]]
+name = "boot-lpi4a-20250323_154524.ext4.zst"
+size = 73219435
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250323/boot-lpi4a-20250323_154524.ext4.zst",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "dfde2ad405e328625424752d6b24ab89855a59870f9190ef430bb54ca2c125b8"
+sha512 = "4180240e0e168e901fd509ff7adb3176caf5a1ebe3a6d25f80b2efda4290b5169a0a453e5573d33f21e2ca85641dc80e83059427cf5128e84ee075dd8ad1c380"
+[[distfiles]]
+name = "root-lpi4a-20250323_154524.ext4.zst"
+size = 1333298432
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250323/root-lpi4a-20250323_154524.ext4.zst",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "75a3d9992264ad13fec41b2171a4877e4a097e217c4e3eee358ceb4d938bf419"
+sha512 = "d0248f83c11b5990c1c77325de4497aa1a86ace0ae7461ad2ecda0333553782421d95b6c88c769490305fae43b51db685e26d07dc6d5c0c52a17fe51c6b5311e"
+
+[metadata]
+desc = "RevyOS 20250323 image for Sipeed LicheePi 4A"
+upstream_version = "20250323"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "boot-lpi4a-20250323_154524.ext4.zst", "root-lpi4a-20250323_154524.ext4.zst",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+boot = "boot-lpi4a-20250323_154524.ext4.zst"
+root = "root-lpi4a-20250323_154524.ext4.zst"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14534401353
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14534401353

--- a/manifests/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20250323.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20250323.0.toml
@@ -1,0 +1,33 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-16g-main.bin"
+size = 992728
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250323/u-boot-with-spl-lpi4a-16g-main.bin",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "946ef12ac79f59a6f43c63c534477776d2b07d7ce8919f4c7d05ed29ddfad30d"
+sha512 = "e626d1ee7617095179fa31394bf0f129225be9527b9042d62957051b11303298d3c46fe0c2d053046cde192c3cf62ea687f4616028f499927603a50bd39144c8"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (16G RAM) and RevyOS 20250323"
+upstream_version = "20250323"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-16g-main.bin",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-16g-main.bin"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14534401353
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14534401353

--- a/manifests/board-image/uboot-revyos-sipeed-lpi4a-8g/0.20250323.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-lpi4a-8g/0.20250323.0.toml
@@ -1,0 +1,33 @@
+format = "v1"
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-main.bin"
+size = 1032312
+urls = [ "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250323/u-boot-with-spl-lpi4a-main.bin",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "a9b57cfbd4ffaa5031aa39e1e22eaa8169654712e41f7ad5ae453d22da8e0807"
+sha512 = "fd2389e3e3a8198f56a56711d8f662ab07c0f8851927111ae4b6e5d1e22cd66419d0ea5e362eb1622ebd0b424480c10dfda1833494a1b30e203b2724d33d987c"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (8G RAM) and RevyOS 20250323"
+upstream_version = "20250323"
+[[metadata.service_level]]
+level = "good"
+
+[blob]
+distfiles = [ "u-boot-with-spl-lpi4a-main.bin",]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[metadata.vendor]
+name = "PLCT"
+eula = ""
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-main.bin"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14534401353
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14534401353


### PR DESCRIPTION

Bump image revyos in device sipeed-lpi4a to version 20250323

Ident: dfbe0404e04ce51903b71ddc2d8abaaa21e4f3955484ef97d0c2f8a317cbdcc1

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14529812342
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14529812342
