### PR TITLE
Bump image buildroot in device sipeed-licheervnano to version 20250319

### DIFF
--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250319.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250319.0.toml
@@ -1,0 +1,32 @@
+format = "v1"
+[[distfiles]]
+name = "2025-03-19-15-13-e4e133.img.xz"
+size = 145585860
+urls = [ "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250319/2025-03-19-15-13-e4e133.img.xz",]
+restrict = [ "mirror",]
+
+[distfiles.checksums]
+sha256 = "710b4235ba1da752c843bdacc350209032a54e3f4fa3cb42289d7793fe61b46b"
+sha512 = "9d7e9f14dcfad4a9a4cfe5dcf8dfbeb966bfbd13b12a4ce4a01188e9912facb649f4411c849c569f6216b9358b79035cfcd74c59ca1e725e4e5e2baa15612f3e"
+
+[metadata]
+desc = "buildroot  for LicheeRV Nano with version 20250319"
+service_level = []
+upstream_version = "20250319"
+
+[blob]
+distfiles = [ "2025-03-19-15-13-e4e133.img.xz",]
+
+[provisionable]
+strategy = "dd_v1"
+
+[metadata.vendor]
+name = "Sipeed"
+eula = ""
+
+[provisionable.partition_map]
+disk = "2025-03-19-15-13-e4e133.img"
+
+# This file is created by program Sync Package Index inside support-matrix
+# Run ID: 14534401353
+# Run URL: https://github.com/wychlw/support-matrix/actions/runs/14534401353

--- a/provisioner/config.yml
+++ b/provisioner/config.yml
@@ -520,6 +520,10 @@ image_combos:
     packages:
       - board-image/revyos-milkv-meles
       - board-image/uboot-revyos-milkv-meles-16g
+  - id: buildroot-sdk-sipeed-licheervnano
+    display_name: buildroot  for LicheeRV Nano
+    packages:
+      - board-image/buildroot-sdk-sipeed-licheervnano
 devices:
   - id: awol-d1dev
     display_name: "Allwinner Nezha D1"
@@ -725,6 +729,7 @@ devices:
           - buildroot-sdk-sipeed-licheervnano-linux-freertos
           - debian-fishwaldo-sipeed-licheervnano
 
+          - buildroot-sdk-sipeed-licheervnano
   - id: sipeed-maix1
     display_name: "Sipeed Maix-I"
     variants:


### PR DESCRIPTION

Bump image buildroot in device sipeed-licheervnano to version 20250319

Ident: dc46a1da14afad2ddaf7208fcec8574045dc157a5521a69de1653deffcc41ae0

This PR is created by program Sync Package Index inside support-matrix

Run ID: 14529812342
Run URL: https://github.com/wychlw/support-matrix/actions/runs/14529812342
