### PR TITLE
Swap buildroot-sdk-milkv-{duo,duo256m} and buildroot-sdk-milkv-{duo,duo256m}-python v1.0.7 image

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duo-python/1.0.7.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo-python/1.0.7.toml
@@ -1,28 +1,28 @@
 format = "v1"
 
 [metadata]
-desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) v1.0.7-2023-1223 (with Python)"
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) v1.0.7-2023-1223"
 vendor = { name = "Milk-V", eula = "" }
 
 [[distfiles]]
-name = "milkv-duo-python-v1.0.7-2023-1223.img.zip"
-size = 62044626
+name = "milkv-duo-v1.0.7-2023-1223.img.zip"
+size = 31653399
 urls = [
-  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo-python-v1.0.7-2023-1223.img.zip",
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo-v1.0.7-2023-1223.img.zip",
 ]
 restrict = ["mirror"]
 
 [distfiles.checksums]
-sha256 = "d421c967ef70df2e09c3de2094beadec30df8da01cc8af492cd188835062b717"
-sha512 = "da0671c502a79e58c92c757d4ff2294e199ec0d94845e236ade0ff5afbf55bb97ad341b0522068cec3dfc1555d9402adfd8fa8727a82a096b30268a92fa799db"
+sha256 = "b6c21cc7e3ef0567adec77e47d66fccdb58f883d45316ec909d7e48a151dbbb3"
+sha512 = "76ec3efa640742eb3ca7928758ee371ddf9da1d1d9b6884e71fe866672d8aaf6c46ffa8de1360388e0cea4dd766afd3096f12b50533014afe9c3b97e70871ace"
 
 [blob]
 distfiles = [
-  "milkv-duo-python-v1.0.7-2023-1223.img.zip",
+  "milkv-duo-v1.0.7-2023-1223.img.zip",
 ]
 
 [provisionable]
 strategy = "dd-v1"
 
 [provisionable.partition_map]
-disk = "milkv-duo-python-v1.0.7-2023-1223.img"
+disk = "milkv-duo-v1.0.7-2023-1223.img"

--- a/manifests/board-image/buildroot-sdk-milkv-duo/1.0.7.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo/1.0.7.toml
@@ -1,28 +1,28 @@
 format = "v1"
 
 [metadata]
-desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) v1.0.7-2023-1223"
+desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) v1.0.7-2023-1223 (with Python)"
 vendor = { name = "Milk-V", eula = "" }
 
 [[distfiles]]
-name = "milkv-duo-v1.0.7-2023-1223.img.zip"
-size = 31653399
+name = "milkv-duo-python-v1.0.7-2023-1223.img.zip"
+size = 62044626
 urls = [
-  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo-v1.0.7-2023-1223.img.zip",
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo-python-v1.0.7-2023-1223.img.zip",
 ]
 restrict = ["mirror"]
 
 [distfiles.checksums]
-sha256 = "b6c21cc7e3ef0567adec77e47d66fccdb58f883d45316ec909d7e48a151dbbb3"
-sha512 = "76ec3efa640742eb3ca7928758ee371ddf9da1d1d9b6884e71fe866672d8aaf6c46ffa8de1360388e0cea4dd766afd3096f12b50533014afe9c3b97e70871ace"
+sha256 = "d421c967ef70df2e09c3de2094beadec30df8da01cc8af492cd188835062b717"
+sha512 = "da0671c502a79e58c92c757d4ff2294e199ec0d94845e236ade0ff5afbf55bb97ad341b0522068cec3dfc1555d9402adfd8fa8727a82a096b30268a92fa799db"
 
 [blob]
 distfiles = [
-  "milkv-duo-v1.0.7-2023-1223.img.zip",
+  "milkv-duo-python-v1.0.7-2023-1223.img.zip",
 ]
 
 [provisionable]
 strategy = "dd-v1"
 
 [provisionable.partition_map]
-disk = "milkv-duo-v1.0.7-2023-1223.img"
+disk = "milkv-duo-python-v1.0.7-2023-1223.img"

--- a/manifests/board-image/buildroot-sdk-milkv-duo256m-python/1.0.7.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo256m-python/1.0.7.toml
@@ -1,28 +1,28 @@
 format = "v1"
 
 [metadata]
-desc = "Official Buildroot SDK image for Milk-V Duo (256M RAM) v1.0.7-2023-1223 (with Python)"
+desc = "Official Buildroot SDK image for Milk-V Duo (256M RAM) v1.0.7-2023-1223"
 vendor = { name = "Milk-V", eula = "" }
 
 [[distfiles]]
-name = "milkv-duo256m-python-v1.0.7-2023-1223.img.zip"
-size = 49539010
+name = "milkv-duo256m-v1.0.7-2023-1223.img.zip"
+size = 31975758
 urls = [
-  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo256m-python-v1.0.7-2023-1223.img.zip",
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo256m-v1.0.7-2023-1223.img.zip",
 ]
 restrict = ["mirror"]
 
 [distfiles.checksums]
-sha256 = "52d0a5bbb70e03eb32bf3dbaa23dd3aff19d5449ce62e101c1d18d794fcc7552"
-sha512 = "383c3c358fe5b2f89b4c8aeb877a1609240573a2d484e9f732ea97d38d1001f9652e38826b049c88ca9e5c0c3024e97818a7823340d440445a301eb1ab001b23"
+sha256 = "63670f3c26e0eea8d76aa0f532cc7c8b0a279309c2b7d57f5f7f82de9345d0c7"
+sha512 = "d626898c9feed6b9f4b7541900201cebe2b8f1eb9c1f90a07d6f2852cd0c2eb34877e7014f9201409300c244dec2c800f394c8e18388ba6d9dcf3a67dbf28924"
 
 [blob]
 distfiles = [
-  "milkv-duo256m-python-v1.0.7-2023-1223.img.zip",
+  "milkv-duo256m-v1.0.7-2023-1223.img.zip",
 ]
 
 [provisionable]
 strategy = "dd-v1"
 
 [provisionable.partition_map]
-disk = "milkv-duo256m-python-v1.0.7-2023-1223.img"
+disk = "milkv-duo256m-v1.0.7-2023-1223.img"

--- a/manifests/board-image/buildroot-sdk-milkv-duo256m/1.0.7.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duo256m/1.0.7.toml
@@ -1,28 +1,28 @@
 format = "v1"
 
 [metadata]
-desc = "Official Buildroot SDK image for Milk-V Duo (256M RAM) v1.0.7-2023-1223"
+desc = "Official Buildroot SDK image for Milk-V Duo (256M RAM) v1.0.7-2023-1223 (with Python)"
 vendor = { name = "Milk-V", eula = "" }
 
 [[distfiles]]
-name = "milkv-duo256m-v1.0.7-2023-1223.img.zip"
-size = 31975758
+name = "milkv-duo256m-python-v1.0.7-2023-1223.img.zip"
+size = 49539010
 urls = [
-  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo256m-v1.0.7-2023-1223.img.zip",
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.0.7/milkv-duo256m-python-v1.0.7-2023-1223.img.zip",
 ]
 restrict = ["mirror"]
 
 [distfiles.checksums]
-sha256 = "63670f3c26e0eea8d76aa0f532cc7c8b0a279309c2b7d57f5f7f82de9345d0c7"
-sha512 = "d626898c9feed6b9f4b7541900201cebe2b8f1eb9c1f90a07d6f2852cd0c2eb34877e7014f9201409300c244dec2c800f394c8e18388ba6d9dcf3a67dbf28924"
+sha256 = "52d0a5bbb70e03eb32bf3dbaa23dd3aff19d5449ce62e101c1d18d794fcc7552"
+sha512 = "383c3c358fe5b2f89b4c8aeb877a1609240573a2d484e9f732ea97d38d1001f9652e38826b049c88ca9e5c0c3024e97818a7823340d440445a301eb1ab001b23"
 
 [blob]
 distfiles = [
-  "milkv-duo256m-v1.0.7-2023-1223.img.zip",
+  "milkv-duo256m-python-v1.0.7-2023-1223.img.zip",
 ]
 
 [provisionable]
 strategy = "dd-v1"
 
 [provisionable.partition_map]
-disk = "milkv-duo256m-v1.0.7-2023-1223.img"
+disk = "milkv-duo256m-python-v1.0.7-2023-1223.img"


### PR DESCRIPTION
In this commit of [provisioner/config.yml](https://github.com/milkv-duo/duo-buildroot-sdk/commit/ef8882650dfa382137cd24f180490cae7e36d37e), the meaning of the "-python" suffix in ``buildroot-sdk-milkv-duo-python`` and ``buildroot-sdk-milkv-duo256m-python`` changed from "with python" to "lite" or "without python". This change applies to version v1.0.8 and newer, but not to v1.0.7.

In this PR, I changed the locations of the two v1.0.7 images. This is actually the only version that releases both Python and non-Python variants.