### PR TITLE
board-image/buildroot-sdk-milkv-duos-sd: add image version Duo-V1.1.1, Duo-V1.1.2, v1.1.4 and fix v1.1.3, v2.0.0

### DIFF
--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.1.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.1.toml
@@ -1,0 +1,31 @@
+format = "v1"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo S v1.1.1-2024-0528 (SD card)"
+vendor = { name = "Milk-V", eula = "" }
+upstream_version = "Duo-V1.1.2"
+
+[[distfiles]]
+name = "milkv-duos-sd-v1.1.1-2024-0528.img.zip"
+size = 61753217
+urls = [
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.1.1/milkv-duos-sd-v1.1.1-2024-0528.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7b644e893a8e86ab8cbc7d29de41cabe99e7eb126b69f59241c85822ccefb90d"
+sha512 = "eb0180a7bf0116012755a895ce8a18a8042b53ec0994dabca653d5d87788c4c53349c173d6d6cc647e46e6d8250483544d98946c17ec3abd75e75f4bb209d4df"
+
+[blob]
+distfiles = [
+  "milkv-duos-sd-v1.1.1-2024-0528.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "milkv-duos-sd-v1.1.1-2024-0528.img"
+
+# Manually created by Kosaka Reiya

--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.2.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.2.toml
@@ -1,0 +1,31 @@
+format = "v1"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo S v1.1.2-2024-0801 (SD card)"
+vendor = { name = "Milk-V", eula = "" }
+upstream_version = "Duo-V1.1.2"
+
+[[distfiles]]
+name = "milkv-duos-sd-v1.1.2-2024-0801.img.zip"
+size = 61835735
+urls = [
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/Duo-V1.1.2/milkv-duos-sd-v1.1.2-2024-0801.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "e532a3486798a3a901f94443ca1ef528fbc724c1c17b595d0fb4c43ae4bc4b37"
+sha512 = "e23a93c138ebfb9c6da2f32cacb5601e7d5cc5789d9b17baaf056175ac5051504536710b7f5b992d8feb2baaa118d783a7a36405ecdf1bf2a37565b58332821d"
+
+[blob]
+distfiles = [
+  "milkv-duos-sd-v1.1.2-2024-0801.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "milkv-duos-sd-v1.1.2-2024-0801.img"
+
+# Manually created by Kosaka Reiya

--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.3.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.3.toml
@@ -1,19 +1,21 @@
 format = "v1"
+
 [[distfiles]]
 name = "milkv-duos-sd-v1.1.3-2024-0930.img.zip"
 size = 70391226
-urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.3/milkv-duos-sd-v1.1.3-2024-0930.img.zip",]
-restrict = [ "mirror",]
+urls = ["https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.3/milkv-duos-sd-v1.1.3-2024-0930.img.zip", ]
+restrict = ["mirror", ]
 
 [distfiles.checksums]
 sha256 = "df8f970693fb101e6483cd80a54f0b7c0f4796e707b845abda96d96b7fea5ab0"
 sha512 = "85e9926d077afae9cbe160d833835c9f82d8029590495645b4b308a0d7ad3d626e7116980aaa3d03f2c083a122483180a88ca9dab7e0a93d89d9b506a99f9814"
 
 [metadata]
-desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duos-sd-v1.1.3-2024-0930.img.zip"
+desc = "Official Buildroot SDK image for Milk-V Duo S v1.1.3 (SD card)"
+upstream_version = "v1.1.3"
 
 [blob]
-distfiles = [ "milkv-duos-sd-v1.1.3-2024-0930.img.zip",]
+distfiles = ["milkv-duos-sd-v1.1.3-2024-0930.img.zip", ]
 
 [provisionable]
 strategy = "dd-v1"
@@ -29,3 +31,4 @@ disk = "milkv-duos-sd-v1.1.3-2024-0930.img"
 # Run: In local
 
 # Manually fixed restrict
+# Manually fix again by Kosaka Reiya

--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.4.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/1.1.4.toml
@@ -1,0 +1,31 @@
+format = "v1"
+
+[metadata]
+desc = "Official Buildroot SDK image for Milk-V Duo S v1.1.4 (SD card)"
+vendor = { name = "Milk-V", eula = "" }
+upstream_version = "v1.1.4"
+
+[[distfiles]]
+name = "milkv-duos-sd-v1.1.4.img.zip"
+size = 70978802
+urls = [
+  "https://github.com/milkv-duo/duo-buildroot-sdk/releases/download/v1.1.4/milkv-duos-sd-v1.1.4.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ff7cd27320573103c49f4365ed261aec664446535e329835bbc2364683711c8f"
+sha512 = "cd6554f1a58119359cbb9bc2d52d37d0c687ee93c590a3f02e27bf5d8e0cacd69bd6ff224acd38ec4a0aa17bec6f303f5975857f85213e55cd825c4f76b3a290"
+
+[blob]
+distfiles = [
+  "milkv-duos-sd-v1.1.4.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "milkv-duos-sd-v1.1.4.img"
+
+# Manually created by Kosaka Reiya

--- a/manifests/board-image/buildroot-sdk-milkv-duos-sd/2.0.0.toml
+++ b/manifests/board-image/buildroot-sdk-milkv-duos-sd/2.0.0.toml
@@ -1,19 +1,21 @@
 format = "v1"
+
 [[distfiles]]
 name = "milkv-duos-musl-riscv64-sd_v2.0.0.img.zip"
 size = 70543302
-urls = [ "https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duos-musl-riscv64-sd_v2.0.0.img.zip",]
-restrict = [ "mirror",]
+urls = ["https://github.com/milkv-duo/duo-buildroot-sdk-v2/releases/download/v2.0.0/milkv-duos-musl-riscv64-sd_v2.0.0.img.zip", ]
+restrict = ["mirror", ]
 
 [distfiles.checksums]
 sha256 = "04b88c4c43adeee2c7c266188d39c7bc3c54fdc1f1d317bded5a7afe6844a1e8"
 sha512 = "5f64d92c08b589af18505e71199e7b7e1e14dc6fe0ddb3800853caf85372765863dd25c29d8fb5eb799873241ac084f9231ea33bd2debefcb76e93ace381061e"
 
 [metadata]
-desc = "Official Buildroot SDK image for Milk-V Duo (64M RAM) milkv-duos-musl-riscv64-sd_v2.0.0.img.zip"
+desc = "Official Buildroot SDK image for Milk-V Duo S v2.0.0 (SD card)"
+upstream_version = "v2.0.0"
 
 [blob]
-distfiles = [ "milkv-duos-musl-riscv64-sd_v2.0.0.img.zip",]
+distfiles = ["milkv-duos-musl-riscv64-sd_v2.0.0.img.zip", ]
 
 [provisionable]
 strategy = "dd-v1"
@@ -30,3 +32,4 @@ disk = "milkv-duos-musl-riscv64-sd_v2.0.0.img"
 # Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/12910390785
 
 # Manually fixed restrict
+# Manually fix again by Kosaka Reiya


### PR DESCRIPTION
Add old image Duo-V1.1.1, Duo-V1.1.2 and v1.1.4 for Milkv DuoS