### PR TITLE
board-image/buildroot-sdk-sipeed-licheervnano: add missing versions

### DIFF
--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240510.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240510.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240510"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240510"
+
+[[distfiles]]
+name = "c906-2024-05-10-14-12-b9dd20.img.gz"
+size = 181969637
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240510/c906-2024-05-10-14-12-b9dd20.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "6263c5199909da71e4ef27ba5a09a45bb35ad927ba3a621f12c46f2fc1b7d64a"
+sha512 = "f5270950f81103d6621a57da1d204473bcfb53c89abb4cb82a32583331440ca35aa406abc33973943f5e4a9af5143b4072a239caf944b811e2bf0e3d123ee520"
+
+[blob]
+distfiles = [
+  "c906-2024-05-10-14-12-b9dd20.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "c906-2024-05-10-14-12-b9dd20.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240513.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240513.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240513"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240513"
+
+[[distfiles]]
+name = "2024-05-13-18-10-f3ea49.img.gz"
+size = 176703127
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240513/2024-05-13-18-10-f3ea49.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "068a90a85c8afe23fa38cf5c37d8c64e8f2364ceef66ba33431156b170bae155"
+sha512 = "71690cbf4464ae6598e6882fef5cc9a389a9b4d30b3ae1caa7e044c858cb5ccdb1bc98c0cd93869154fa3e2d141d7571a1fca6503987bfe61b8aaf19df0c41f7"
+
+[blob]
+distfiles = [
+  "2024-05-13-18-10-f3ea49.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-05-13-18-10-f3ea49.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240514.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240514.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240514"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240514"
+
+[[distfiles]]
+name = "2024-05-14-10-00-646bd6.img.gz"
+size = 176684432
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240514/2024-05-14-10-00-646bd6.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "74fd0f62a0cd466b6633d052ba136d48aa51ebd0aacbf732ef52120eed66b866"
+sha512 = "8891fdc7fc10b1e5dedb0a4934c2e567cd1f312a4bfcb4732bce651b98b8c598905e7cb5ab7ff7425fd1571a47b74e88b069c36ada48e56494560713b146d967"
+
+[blob]
+distfiles = [
+  "2024-05-14-10-00-646bd6.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-05-14-10-00-646bd6.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240515.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240515.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240515"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240515"
+
+[[distfiles]]
+name = "2024-05-15-16-57-9af3db.img.gz"
+size = 183401678
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240515/2024-05-15-16-57-9af3db.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d081b33c993a02babf23e9bebf6d83257f4337eb85edb6ca5622c480a3187657"
+sha512 = "60f5815bb6f8a6fedf0d2f9e92af4eeec0987ea745355516e4719ec5cf2baae84630d38af60add635c589584afcb2962f35c58ba962659f095d71b8f2405eaf0"
+
+[blob]
+distfiles = [
+  "2024-05-15-16-57-9af3db.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-05-15-16-57-9af3db.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240528.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240528.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240528"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240528"
+
+[[distfiles]]
+name = "2024-05-28-17-33-82a0b7.img.xz"
+size = 121049396
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240528/2024-05-28-17-33-82a0b7.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "281ddcf662827f238dbc4a3172b6e91315dec3b07c78980f2035cec0bddcfcb5"
+sha512 = "78a017b3d3c5d1836fbf1877c446a9a88b43472ae9fcd66f43afcb1d647a36bbbb9c86076f2cf48b75f5897c07cc448e3254a0a29e8458d919159d251b6c1d0c"
+
+[blob]
+distfiles = [
+  "2024-05-28-17-33-82a0b7.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-05-28-17-33-82a0b7.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240709.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240709.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240709"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240709"
+
+[[distfiles]]
+name = "2024-07-09-18-17-245934.img.xz"
+size = 145059356
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240709/2024-07-09-18-17-245934.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ff602a5420e75c37d96ad5ecca674ddcf3a28aae98f6dea66017ee203bfa269c"
+sha512 = "e780dbb0d2b23960eed8622d0f45f65a46ee86cffd2a5eb00579366f245e5fb2c9c1d57d3d4cdb1cf11a74e3a580e5f8571c5d65449a5f4e3713abdb02c575c5"
+
+[blob]
+distfiles = [
+  "2024-07-09-18-17-245934.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-07-09-18-17-245934.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240726.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240726.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240726"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240726"
+
+[[distfiles]]
+name = "2024-07-26-18-41-fc2bb1.img.xz"
+size = 147941920
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240726/2024-07-26-18-41-fc2bb1.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b10613305f2f936bef06689c7309c1fd93d0433c89d9408984bd27dffd479f11"
+sha512 = "32576f9bb9f962760e0243a0c76ed65a24bc6596cdbc08fab70fe9967e8dc9ce563ed987de2ab4c539bccf4a41ba59d09f3efd9c27715705cce5e14ea33e62bb"
+
+[blob]
+distfiles = [
+  "2024-07-26-18-41-fc2bb1.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-07-26-18-41-fc2bb1.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240807.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240807.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240807"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240807"
+
+[[distfiles]]
+name = "2024-08-07-16-56-b0a69a.img.xz"
+size = 147958320
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240807/2024-08-07-16-56-b0a69a.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "edc5c174599afc7fedbc48d5be5d1aac2fb756c352cdb86832a770a1ece2b5cd"
+sha512 = "6f11337a08a3778ec06f212126334bb58bd945f1247301e869ddd499c4438ab59adef61e6d977626c1004e8ad5a9aee411a8b8a7f3e8e04e02631021f8d1344d"
+
+[blob]
+distfiles = [
+  "2024-08-07-16-56-b0a69a.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-08-07-16-56-b0a69a.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240813.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240813.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240813"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240813"
+
+[[distfiles]]
+name = "2024-08-13-14-43-0de38f.img.xz"
+size = 148590604
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240813/2024-08-13-14-43-0de38f.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1bea443be8bfb678692ebc055f91337c1495da9579a60368ef111994110f0a00"
+sha512 = "faa44ec9de017ce20e41e2a640de1cba4538aad2f8d5dab322faf08aab70f323c6fd67bc935726848f89ec9f12b85c833f16342a78bc5652ca758edb9cacab11"
+
+[blob]
+distfiles = [
+  "2024-08-13-14-43-0de38f.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-08-13-14-43-0de38f.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240816.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240816.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240816"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240816"
+
+[[distfiles]]
+name = "2024-08-16-10-32-713161.img.xz"
+size = 148587548
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240816/2024-08-16-10-32-713161.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ef79cfa49df224b252659f0fd7b720afeacb99f5daa6937ac546dc02a121201f"
+sha512 = "2e14b4664bf404a2060ac42f3c50580666951c59a4fc83a655228465a871368c5c9edc4765db4e03efd5468fe289d50ef8ee8f34e85cb8fd136b3640bc0f4b0d"
+
+[blob]
+distfiles = [
+  "2024-08-16-10-32-713161.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-08-16-10-32-713161.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240905.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240905.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240905"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240905"
+
+[[distfiles]]
+name = "2024-09-05-16-34-752683.img.xz"
+size = 148777168
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240905/2024-09-05-16-34-752683.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "03c7625a994d35f092b84bc8707b6382494a741fa2f2229622e96733ac16d704"
+sha512 = "18d4a8ef856a600091d6c20e0a9c003f8b41eef1c132e18a787db8f7a4901ca0771b1a94eee00849c1de44974d1ec7001c64b34464ed7e4f1bbb991207a03267"
+
+[blob]
+distfiles = [
+  "2024-09-05-16-34-752683.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-09-05-16-34-752683.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240926.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20240926.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20240926"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20240926"
+
+[[distfiles]]
+name = "2024-09-26-19-07-632a76.img.xz"
+size = 149143468
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20240926/2024-09-26-19-07-632a76.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "f0f2e1a409b0b9861679242df4c4aee2b5c4cdf42e544638cb2c85a6ac3c6a59"
+sha512 = "7c663bbb4b0eeb1a6379128ca6f0d7072e29e2d84b174c8b9a6258b1dc4148c562d0fdc5c95514ed7a5287fe922658029ad9a63f251bcbac0c6e2317d2df3dac"
+
+[blob]
+distfiles = [
+  "2024-09-26-19-07-632a76.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-09-26-19-07-632a76.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20241017.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20241017.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20241017"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20241017"
+
+[[distfiles]]
+name = "2024-10-17-14-21-e01183.img.xz"
+size = 149129088
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20241017/2024-10-17-14-21-e01183.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "84ca7fca7d6574a4db785d9d29938d8780f296d8b9fbddc6d174a69dd58ddb98"
+sha512 = "b9a0eda61d63fe41f9fd85c175151cde697d4eb5422daded4357e179c4682ea09e0e19b97f7adf0b8f7eea47110265658f3d23fdaf2cd379bd9e0f0cfd4c772d"
+
+[blob]
+distfiles = [
+  "2024-10-17-14-21-e01183.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-10-17-14-21-e01183.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20241021.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20241021.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20241021"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20241021"
+
+[[distfiles]]
+name = "2024-10-21-15-39-1dd70f.img.xz"
+size = 142989304
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20241021/2024-10-21-15-39-1dd70f.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b8ee17e01aec9e483d3578e28eaebd43a30c158c6fb2011b4a8cc3e8e7d15c23"
+sha512 = "4d667b92f6627b04f2216abd3c599f483292ccc11f69c4bb729e50f3019f6cb5d6f4b950a8e1a88ee1bcc729cb981b4ad2c98f63e60cee0ab8af0b598676497a"
+
+[blob]
+distfiles = [
+  "2024-10-21-15-39-1dd70f.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-10-21-15-39-1dd70f.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20241220.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20241220.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20241220"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20241220"
+
+[[distfiles]]
+name = "2024-12-20-17-31-1fcc2f.img.xz"
+size = 145521928
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20241220/2024-12-20-17-31-1fcc2f.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7fec840044f30f2bb846ad7a46dc788628c3dab71d7ad53e9d435a701fb0171c"
+sha512 = "127651810952f85177f242c370794401176c10c95fd9ad833c3cdcce9b1004acc4937f75ff7c20bd27a217d35e792e7dbba25a73a64a6844519852b09be6af60"
+
+[blob]
+distfiles = [
+  "2024-12-20-17-31-1fcc2f.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2024-12-20-17-31-1fcc2f.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250111.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250111.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250111"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20250111"
+
+[[distfiles]]
+name = "2025-01-11-15-41-48724b.img.xz"
+size = 145562956
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250111/2025-01-11-15-41-48724b.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "febd7342d3ea2563647f602946aaa5af672fc653eaccdf8d9e2d929c2066ed84"
+sha512 = "1fe5103e319b05366cae160a3b4494842d6259573f074280f048ba3b3daf2803d4a5bbc1d789556ed45d32db1e1b958212d2ff4356a6231a8fa3783080c6317f"
+
+[blob]
+distfiles = [
+  "2025-01-11-15-41-48724b.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-01-11-15-41-48724b.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250114.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250114.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250114"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20250114"
+
+[[distfiles]]
+name = "2025-01-14-11-09-741697.img.xz"
+size = 145580772
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250114/2025-01-14-11-09-741697.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "93ee4c9e41bbcc819a2e5650fa8774159ccd3e7ecbb4c1a8c8cb2695a8abdc55"
+sha512 = "aa556b4a464aeaaa2dc22bd9fd022d9801c26052adf4452446b08c5f54e588d1101d7d7c96cd22ad5beb33f41dbe826c27d3efd994530fed797aa44cec4a70ee"
+
+[blob]
+distfiles = [
+  "2025-01-14-11-09-741697.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-01-14-11-09-741697.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250319.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250319.0.toml
@@ -1,7 +1,7 @@
 format = "v1"
 
 [metadata]
-desc = "buildroot  for LicheeRV Nano with version 20250319"
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250319"
 vendor = { name = "Sipeed", eula = "" }
 upstream_version = "20250319"
 
@@ -23,7 +23,7 @@ distfiles = [
 ]
 
 [provisionable]
-strategy = "dd_v1"
+strategy = "dd-v1"
 
 [provisionable.partition_map]
 disk = "2025-03-19-15-13-e4e133.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250417.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250417.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250417"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20250417"
+
+[[distfiles]]
+name = "2025-04-17-20-04-a3ccb5.img.xz"
+size = 145613012
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250417/2025-04-17-20-04-a3ccb5.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1e10e1752d0259a2e6a7b293620478684b2fd473594f715e5758436b15b4241d"
+sha512 = "b04a4f2476da9c4050de73d84653a29c7881004c3d1a7b271774c41ee1f0e439c39fd66e56e873feed27749507b10e9f2a47930254449e6c06427d5ccbc06325"
+
+[blob]
+distfiles = [
+  "2025-04-17-20-04-a3ccb5.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-04-17-20-04-a3ccb5.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250729.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250729.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250729"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20250729"
+
+[[distfiles]]
+name = "2025-07-29-18-59-21ffda.img.xz"
+size = 173187752
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250729/2025-07-29-18-59-21ffda.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "4259ecc95e3ededdd88418968d45221a93691d5f7779bdb2d0580a05019e8592"
+sha512 = "89642b72d9f35d7412cf4c3476c3a9fe2c8849e217048f2c005ce067e6fac787353e38c94d58074ee0082a6dafff7cb9728a8cf148d5128d404e52c0927bbc66"
+
+[blob]
+distfiles = [
+  "2025-07-29-18-59-21ffda.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-07-29-18-59-21ffda.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250730.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250730.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250730"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20250730"
+
+[[distfiles]]
+name = "2025-07-30-13-43-6aedfa.img.xz"
+size = 173201520
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250730/2025-07-30-13-43-6aedfa.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "16254129b8776989a3557b56a866d5c5e13fbe56d3dd32989e1e1c4d2cefa0d8"
+sha512 = "cbe4d446876e8e96966c6d172b9155ab14146eb6d03edd28e325b8b037ddef8d9d9ffd488fb78797d0a2d53fb4220814386437f5e46aca27d4dc00d64625d986"
+
+[blob]
+distfiles = [
+  "2025-07-30-13-43-6aedfa.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-07-30-13-43-6aedfa.img"

--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250804.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20250804.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20250804"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20250804"
+
+[[distfiles]]
+name = "2025-08-04-20-43-891bfb.img.xz"
+size = 173208612
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20250804/2025-08-04-20-43-891bfb.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "2cbe4649c366cf6c514f7a536d1d0299f517297d7a18cbc19685a7d41787e389"
+sha512 = "425ac2d2468d7feeae6cda4401bfa76ffd0f08034890715244ee61cf56eb884dd98e252e18a10cdf02089f8a98b9803f2d391bc3a15abc41e8dc13d8c5ad16c0"
+
+[blob]
+distfiles = [
+  "2025-08-04-20-43-891bfb.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-08-04-20-43-891bfb.img"


### PR DESCRIPTION
From upstream version 20240422 to the latest.