### PR TITLE
Fix broken bianbu-bpi-f3 manifest and unify bianbu upstream_version format

### DIFF
--- a/manifests/board-image/bianbu-bpi-f3/2.0.4.toml
+++ b/manifests/board-image/bianbu-bpi-f3/2.0.4.toml
@@ -3,18 +3,19 @@ format = "v1"
 [metadata]
 desc = "Official bianbu desktop image for Banana Pi F3 version v2.0.4"
 vendor = { name = "bpi_f3", eula = "" }
+upstream_version = "v2.0.4"
 
 [[distfiles]]
 name = "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.img.zip"
-size = 196
+size = 2632497569
 urls = [
-  "https://archive.spacemit.com/image/k1/version/bianbu/bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.img.zip",
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.4/bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.img.zip",
 ]
 restrict = ["mirror"]
 
 [distfiles.checksums]
-sha256 = "80c3fe2ae1062abf56456f52518bd670f9ec3917b7f85e152b347ac6b6faf880"
-sha512 = "9002a0475fdb38541e78048709006926655c726e93e823b84e2dbf5b53fd539a5342e7266447d23db0e5528e27a19961b115b180c94f2272ff124c7e5c8304e7"
+sha256 = "436ae1db2c8ca4d860e726f2ff7ed6b0da4947e9b67ee8fac6db263d1625e03f"
+sha512 = "98c41db327ec78607d9f9ce67eddc2b2340f65cbbbb45b9f840faef1fc2e285de8c509f816fe9fce6cac4e893b02ae087a7e04f87e644ddca3d607a337b2cf32"
 
 [blob]
 distfiles = [
@@ -31,4 +32,4 @@ disk = "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.img"
 # Run ID: 13302859068
 # Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/13302859068
 
-# Fix format by Kosaka Reiya
+# Manually fixed by Kosaka Reiya

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.1.toml
@@ -1,9 +1,9 @@
 format = "v1"
 
 [metadata]
-desc = "Official Bianbu Desktop 2.1.1 for SpacemiT K1, SD image"
+desc = "Official Bianbu Desktop v2.1.1 for SpacemiT K1, SD image"
 vendor = { name = "SpacemiT", eula = "" }
-upstream_version = "2.1.1"
+upstream_version = "v2.1.1"
 
 [[metadata.service_level]]
 level = "good"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.1.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.1.1.toml
@@ -1,9 +1,9 @@
 format = "v1"
 
 [metadata]
-desc = "Official Bianbu Minimal 2.1.1 for SpacemiT K1, SD image"
+desc = "Official Bianbu Minimal v2.1.1 for SpacemiT K1, SD image"
 vendor = { name = "SpacemiT", eula = "" }
-upstream_version = "2.1.1"
+upstream_version = "v2.1.1"
 
 [[distfiles]]
 name = "bianbu-24.04-minimal-k1-v2.1.1-release-20250305135614.img.zip"


### PR DESCRIPTION
Except changes in this PR, while checking dist file URL of  ``board-image/bianbu-bpi-f3`` and ``board-image/bianbu-desktop-spacemit-k1-sd``, I found that these two combos are the same thing.

```toml
# manifests/board-image/bianbu-bpi-f3/2.0.4.toml
urls = [
  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.4/bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.img.zip",
]
```

```toml
# manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.1.toml
urls = [
  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip",
]
```

Maybe we should fix this later.