### PR TITLE
board-image/bianbu-{desktop,minimal}-spacemit-k1-sd: new versions from v2.0.0 to v3.0.0

### DIFF
--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.img.zip"
+size = 2529029381
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0/bianbu-24.04-desktop-k1-v2.0-release-20241021195251.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "895f5b0c6ea54d127f5e277d612d9023821fa4b834782d009316d0fac65a721c"
+sha512 = "a95946bff3fa2d8278083c8e003a5ef3ae74d77459faaf97483d7b72895c168e0cfa6b756a3d85360ea1c312660fc5834a18e688d7522bfdc9f965f40f58d6a2"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.img.zip"
+size = 2530674041
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.1/bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "6f1a28cdb4d829325770338e2365832834ba5ceccef0bbe6049f71a48de2709f"
+sha512 = "f4efc90e58a402a91a67418d9dd2bd8013aa43a61961fa7b8b26bd3ae5b7af07bc62f5bfa71fdeb0ac503069fd9aba7ed2da89b5343f8fc387a091a8f27c968f"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.2.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.2.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.2 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.img.zip"
+size = 2533721277
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.2/bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "6c82ff57c836e343647cde4d7e5879f4b32e67bd5b787ad86ba2b3d458b560cf"
+sha512 = "7d6bce2459070eaa45cc481d7e6623f627678f1972f77df6303f8d483961369ba87d6786690b26ed1c3e9e9ddf5396fc9e19eb10591b337400fdf9c69430b479"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.4.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.0.4.toml
@@ -1,8 +1,8 @@
 format = "v1"
 
 [metadata]
-desc = "Official bianbu desktop image for Banana Pi F3 version v2.0.4"
-vendor = { name = "bpi_f3", eula = "" }
+desc = "Official Bianbu Desktop v2.0.4 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
 upstream_version = "v2.0.4"
 
 [[distfiles]]
@@ -27,9 +27,3 @@ strategy = "dd-v1"
 
 [provisionable.partition_map]
 disk = "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.img"
-
-# This file is created by CI Sync Package Index inside support-matrix
-# Run ID: 13302859068
-# Run URL: https://github.com/ruyisdk/support-matrix/actions/runs/13302859068
-
-# Manually fixed by Kosaka Reiya

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.img.zip"
+size = 2615616404
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1/bianbu-24.04-desktop-k1-v2.1-release-20250124144655.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7e0ead6b6cc06beb086222d2e5f8a0522b4966ab80edb3f9318ed2fb19fbfc9c"
+sha512 = "9a25792e6e768f339ad6b5c7237feca1e5b530ee8e27351d0860400dfed4d08972bfa3cd8796e2fa0860bcf6c36cee64cd89cec9a380bf50303dae821cb31a7f"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.2.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.2.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1.2 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.img.zip"
+size = 2575158003
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.2/bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "eec596fb79072218a42e29fcb2a58ac40510414d33c46e973bb79446f6edb5c0"
+sha512 = "f9265283713d2e4681ac10eb6aab69b805215aa98f62c75e4895a6f29f88fe9ba4601679ac2003cb0464909a14fa859baeffb72176cfc1f239c648b172ae320f"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.2.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.2.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.2 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.img.zip"
+size = 2639865457
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2/bianbu-24.04-desktop-k1-v2.2-release-20250430190125.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "e279f29a2610c369aa2558b9c66d3ef0ca300c44dc6c1e93f0cc44bc9911aa80"
+sha512 = "44515a8449d98e9077d2e89d99510078f0e23447f937f9f741384b24d89fdb2b305c33a48168152a34cd83606337d5582778c237ff91887bc8b05aa6d28f604d"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/3.0.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/3.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v3.0 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.img.zip"
+size = 2596823315
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0/bianbu-25.04-desktop-k1-v3.0-release-20250725125828.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "a553471dec29078b1c2749c8c385d989dadade20bda6daa5d65592d3360e71ad"
+sha512 = "3487004a59abe2bbdeba17f936a41de5e244dcd5e33223ee9c344d913886602705511261fc432dec24e8394c5a4d7c770ee93bfdc93abb72a17896250ff5b16f"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.0 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.0-release-20241021191106.img.zip"
+size = 221126819
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0/bianbu-24.04-minimal-k1-v2.0-release-20241021191106.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "8fe7f52e69a00e1bd5cd96221663299e694a477940a4695a9abfa6ad498ddc1e"
+sha512 = "f8f94dd150fa040f8334ad9045332f8860e4929fa9bac17d704d799db7c762081a69f3aab816c6eea6b78b390a46032cf59d6764043c13377b73be9c728bbdd6"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.0-release-20241021191106.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.0-release-20241021191106.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.0.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.1"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.0.1-release-20241025230306.img.zip"
+size = 220751856
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.1/bianbu-24.04-minimal-k1-v2.0.1-release-20241025230306.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "3844ec264d84939beb3b05a98e038744849a6867b77dc31b8914b46a0be48290"
+sha512 = "3e22dc140b404ba20e609c92b86cdf277ddb5f7a8a793bece9b6f3f5ca43c55de2bed33e1703e17046da9fb8cf6ee9a32029afab2d2546b5404bf6713345936c"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.0.1-release-20241025230306.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.0.1-release-20241025230306.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.2.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.2.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.0.2 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.2"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.0.2-release-20241111214520.img.zip"
+size = 222827599
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.2/bianbu-24.04-minimal-k1-v2.0.2-release-20241111214520.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "4f821b9be7ed3ede6f2ff301cc624175c6c46e9d504dd08e152a5d4c78c22ebf"
+sha512 = "d289d22c40081e7ea899a5ae25649977125210eabdb0a670f64246cd186d3c300ecbf4438176afe6054fe93988be6bcaae83bb690e1977fd1980ffb86f82146b"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.0.2-release-20241111214520.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.0.2-release-20241111214520.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.4.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.0.4.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.0.4 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.4"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.0.4-release-20241205234138.img.zip"
+size = 248572469
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.4/bianbu-24.04-minimal-k1-v2.0.4-release-20241205234138.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "2871c6760c6a2f64deb184fb9bbeddd5984117d6c79f0f6a2f18f4a680ac12e7"
+sha512 = "7d4f9aa8e107bd2b22356149467c4c274292e449f19014147d329117fdc8ed04a7475f01c7651de795a4957f744c2ac46f92423135b023ddf3e266a5243c78d8"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.0.4-release-20241205234138.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.0.4-release-20241205234138.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.1.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.1.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.1-release-20250124140410.img.zip"
+size = 251776265
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1/bianbu-24.04-minimal-k1-v2.1-release-20250124140410.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b81f154be6b8382639fbe92f44bb47abdf37d251106dd63277128eaae8ef4ccb"
+sha512 = "824746bd0f00a5b153f87b682d8490c2c8761a31f0b4d9f628817bca1259ca9795386cd9ef72bb87b4659ffc46b39eebd95dad69027d1468166cc907aab8a131"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.1-release-20250124140410.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.1-release-20250124140410.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.1.2.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.1.2.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.1.2 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1.2"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.1.2-release-20250421163722.img.zip"
+size = 253730871
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.2/bianbu-24.04-minimal-k1-v2.1.2-release-20250421163722.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c9d0dabdef3e84bc6dbc1b6013a65dcc4a9f6ed30d06b03b615a890de2be6fd3"
+sha512 = "9abaa1d59c4ee12fc28dc2c86c24044deb80f16e21b8f36ac6825c5d4c5b0add7ead65175d7a72b70d68a6b55294913ac052481fa59887371e70d5056f907250"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.1.2-release-20250421163722.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.1.2-release-20250421163722.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.2.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.2.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.2 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.2-release-20250430181626.img.zip"
+size = 257088980
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2/bianbu-24.04-minimal-k1-v2.2-release-20250430181626.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "8330fc0aca3033994b8d5fe7596a499a0f02da72e74ac18142fbf7c6f002461e"
+sha512 = "ba7cae5b07309a68092c3e3f1c6c5114628824e855c2bf6f263a6262777b26321b76dcb46ff7efd41254160e0d04392aed34b1479097e1a2481d9644fea742e7"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.2-release-20250430181626.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.2-release-20250430181626.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/3.0.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/3.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v3.0 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0"
+
+[[distfiles]]
+name = "bianbu-25.04-minimal-k1-v3.0-release-20250725114639.img.zip"
+size = 273156619
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0/bianbu-25.04-minimal-k1-v3.0-release-20250725114639.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1bd4859c0ff6e07e00d40c773d0169c547c0066d3cc07d611f68d7f520651913"
+sha512 = "4fc9a8f0baf0ef46b03499e9d3b4bfc6d1ddfea6694be78ad76b5da5dee79e8b516cb48b44d877c8eb6d6e30331ed2870ce976c30e0995a14d23ea1c2e38d629"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-minimal-k1-v3.0-release-20250725114639.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-25.04-minimal-k1-v3.0-release-20250725114639.img"


### PR DESCRIPTION
+ Remove board-image/bianbu-bpi-f3, this board image did not refer by any entity
+ Add new versions for board-image/bianbu-{desktop,minimal}-spacemit-k1-sd, from v2.0.0 to v3.0.0