### PR TITLE
Update board-image/bianbu-{desktop,minimal}-spacemit-k1-sd manifests

### DIFF
--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.1.toml
@@ -10,15 +10,15 @@ level = "good"
 
 [[distfiles]]
 name = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip"
-size = 560652288
+size = 2616243211
 urls = [
   "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.img.zip",
 ]
 restrict = ["mirror"]
 
 [distfiles.checksums]
-sha256 = "8dabd17c30bdb2c0d4e076417a90b6cddca2031e0e19350fd0d4ee29944a953f"
-sha512 = "1318b6207085af38036445fb7e0a1ed87545417ac018c7a4ae7733f1110c3944d3ff0fbfd6f105905efe003f386660bde20efc529206549f99805761c5adbc85"
+sha256 = "a42a0efc1c55f4942b081a9fc444a9dec853ff165c1fd8cd4775539cc64ed408"
+sha512 = "36adc5b8de585a1a88df9f5d640d12f743ac213747c694116cb0d6a0adb98d50388e891c8952675816beac3d904c1ce2d2b44126477a005cd2dda739d2f210b9"
 
 [blob]
 distfiles = [

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.2.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.2.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.2.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.img.zip"
+size = 2644980899
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2.1/bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "630bea9e2332757957c88696cf3aea542b2183b8c71d6d1ab5fecd66adb51c4c"
+sha512 = "29a7ef1218ee1c5f5b762531203a98a7fc8acddeee2a7daff33b3f564afce44ac032c32584e6c8c25fe02906b9d30044ffcf95e5fb9da9a085c0569c7f394d70"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.img"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1-sd/3.0.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1-sd/3.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v3.0.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0.1"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.img.zip"
+size = 2601233372
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0.1/bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ad998152cdca2bb8344635c2b64a652bcda2c4a0102197a555c8e13164c2f789"
+sha512 = "77866354d81f54c3d4a3625f9f36edf19a4047be175b12edfbf1d8eeb5ff3776a7e4eb55607e70947cfb8748684660ff9a441de3fdd733e5880c97bf2963d8da"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.2.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/2.2.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.2.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-minimal-k1-v2.2.1-release-20250815212223.img.zip"
+size = 262222523
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2.1/bianbu-24.04-minimal-k1-v2.2.1-release-20250815212223.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "03b041be2dc9f48fcd18246e8f09d0dc8dceda21ba990fac1a950a8ed5769431"
+sha512 = "2d308b815619e9089e1bc6480b835d3f3d3a0ae246e993287983c87d7f89d0662846e076d9a7d59b111244c8c4b17761c5761d39fd2a4a8c94ce049801c4ea26"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-minimal-k1-v2.2.1-release-20250815212223.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-minimal-k1-v2.2.1-release-20250815212223.img"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1-sd/3.0.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1-sd/3.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v3.0.1 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0.1"
+
+[[distfiles]]
+name = "bianbu-25.04-minimal-k1-v3.0.1-release-20250815180414.img.zip"
+size = 277557816
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0.1/bianbu-25.04-minimal-k1-v3.0.1-release-20250815180414.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ee646c151ec2d330ae5f580154b02080f8255038abe1ee6fc804da30423cd1d5"
+sha512 = "cb7459b5c6413a463a89f0562e1f0ba65045541aef258b1ce8de29168d086b92d8a0af5d0e03ff8ccb6fb5cdf3b14ad8d38b38a7a77eb2d449c9bb6a59cdceda"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-minimal-k1-v3.0.1-release-20250815180414.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-25.04-minimal-k1-v3.0.1-release-20250815180414.img"


### PR DESCRIPTION
+ Old toml ``manifests/board-image/bianbu-desktop-spacemit-k1-sd/2.1.1.toml`` contains wrong checksum, it is accidentally found by my tool
+ Bianbu upstream released v2.2.1 and v3.0.1