### PR TITLE
board-image/debian-desktop-sdk-milkv-mars-cm-sd: fix 1.0.5+3.6.1 manifest

### DIFF
--- a/manifests/board-image/debian-desktop-sdk-milkv-mars-cm-sd/1.0.5+3.6.1.toml
+++ b/manifests/board-image/debian-desktop-sdk-milkv-mars-cm-sd/1.0.5+3.6.1.toml
@@ -6,9 +6,7 @@ vendor = { name = "Milk-V", eula = "" }
 upstream_version = "V1.0.5"
 
 [[distfiles]]
-name = [
-  "mars-cm_debian-desktop_sdk-v3.6.1_cm4-io-board_sdcard_v1.0.5.img.zip",
-]
+name = "mars-cm_debian-desktop_sdk-v3.6.1_cm4-io-board_sdcard_v1.0.5.img.zip"
 size = 1216117229
 urls = [
   "https://github.com/milkv-mars/mars-buildroot-sdk/releases/download/V1.0.5/mars-cm_debian-desktop_sdk-v3.6.1_cm4-io-board_sdcard_v1.0.5.img.zip",


### PR DESCRIPTION
There is a wrong list