### PR TITLE
board-image/revyos-sipeed-laptop4a: new device support

### DIFF
--- a/entities/device-variant/sipeed-laptop4a@16g.toml
+++ b/entities/device-variant/sipeed-laptop4a@16g.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:xuantie-th1520"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "16g"
+variant_name = "16G RAM"

--- a/entities/device-variant/sipeed-laptop4a@8g.toml
+++ b/entities/device-variant/sipeed-laptop4a@8g.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:xuantie-th1520"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "8g"
+variant_name = "8G RAM"

--- a/entities/device/sipeed-laptop4a.toml
+++ b/entities/device/sipeed-laptop4a.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["device-variant:sipeed-laptop4a@8g", "device-variant:sipeed-laptop4a@16g"]
+unique_among_type_during_traversal = true
+
+[device]
+id = "sipeed-laptop4a"
+display_name = "Sipeed Lichee Book 4A"

--- a/entities/image-combo/revyos-sipeed-laptop4a@16g.toml
+++ b/entities/image-combo/revyos-sipeed-laptop4a@16g.toml
@@ -1,0 +1,13 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:sipeed-laptop4a@16g",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "RevyOS for Sipeed Lichee Book 4A (16G RAM)"
+package_atoms = [
+  "board-image/revyos-sipeed-laptop4a",
+  "board-image/uboot-revyos-sipeed-laptop4a-16g"
+]

--- a/entities/image-combo/revyos-sipeed-laptop4a@8g.toml
+++ b/entities/image-combo/revyos-sipeed-laptop4a@8g.toml
@@ -1,0 +1,13 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:sipeed-laptop4a@8g",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "RevyOS for Sipeed Lichee Book 4A (8G RAM)"
+package_atoms = [
+  "board-image/revyos-sipeed-laptop4a",
+  "board-image/uboot-revyos-sipeed-laptop4a-8g"
+]

--- a/manifests/board-image/revyos-sipeed-laptop4a/0.20240720.0.toml
+++ b/manifests/board-image/revyos-sipeed-laptop4a/0.20240720.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20240720 image for Sipeed Lichee Book 4A"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20240720"
+
+[[distfiles]]
+name = "boot-laptop-20240720_171948.ext4.zst"
+size = 28615663
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20240720/boot-laptop-20240720_171948.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ebb5d69498fbd3e698d1273625d876dd713e0129cedb2ef7db700c9ec5967b81"
+sha512 = "bb69dd109aeb4032767d84dce05edbae97b6344c2d64e7cd7ecad79f048fd378c0cfde3b727fb6042caae143444f1be57b4551570bde65220e6d9462515fb148"
+
+[[distfiles]]
+name = "root-laptop-20240720_171948.ext4.zst"
+size = 1259877342
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20240720/root-laptop-20240720_171948.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "93cd36a6919a937e41916dda9a29a1d15e0560be239e053dd6ae11e542bd48eb"
+sha512 = "bba43b2c327c27ee89fac04b1017b621206ae46b33f9a78e8d4ee6bec961f02e4aadd3c7a1ba43c7421acf03b88626b521d846166869ce9a4fc84be5694bd42a"
+
+[blob]
+distfiles = [
+  "boot-laptop-20240720_171948.ext4.zst",
+  "root-laptop-20240720_171948.ext4.zst",
+]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[provisionable.partition_map]
+boot = "boot-laptop-20240720_171948.ext4"
+root = "root-laptop-20240720_171948.ext4"

--- a/manifests/board-image/revyos-sipeed-laptop4a/0.20250930.0.toml
+++ b/manifests/board-image/revyos-sipeed-laptop4a/0.20250930.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20250930 image for Sipeed Lichee Book 4A"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250930"
+
+[[distfiles]]
+name = "boot-laptop-20250930_113343.ext4.zst"
+size = 74694741
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20250930/boot-laptop-20250930_113343.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "9185f5fb61b999edc8b7b7dc7129390c5f41dd90dd102fcb38b2489f991f1e91"
+sha512 = "17d51d0803d5f84e5cfe06b8e1d6d7ae8e7b3e7d7dfd94bcd1dd1258730a1acd1868d72a72d913b9db1f47f24de10b1f6314d541c6d68a5ab7113b8042cb45ae"
+
+[[distfiles]]
+name = "root-laptop-20250930_113343.ext4.zst"
+size = 1378218041
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20250930/root-laptop-20250930_113343.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "bc271917a4f23aa63f36ae1aa478fe48b2efdb0a4a2dcdb5fc85c544574ca611"
+sha512 = "882dbf31a20565221504402b4ae7018f6092a6b7a15e03fe55b9593dca676c89b989203c2927993f9852364c1452c1b9412ee7dfc76df6a8743aae8c5b93fbef"
+
+[blob]
+distfiles = [
+  "boot-laptop-20250930_113343.ext4.zst",
+  "root-laptop-20250930_113343.ext4.zst",
+]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[provisionable.partition_map]
+boot = "boot-laptop-20250930_113343.ext4"
+root = "root-laptop-20250930_113343.ext4"

--- a/manifests/board-image/revyos-sipeed-laptop4a/0.20251025.0.toml
+++ b/manifests/board-image/revyos-sipeed-laptop4a/0.20251025.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20251025 image for Sipeed Lichee Book 4A"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20251025"
+
+[[distfiles]]
+name = "boot-laptop-20251025_114742.ext4.zst"
+size = 46347480
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20251025/boot-laptop-20251025_114742.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "554d5b9b41a8e7ce8c3f524be3aa97d62ecca7d62bf7bdd5c63e02aaf1a8f234"
+sha512 = "72d3d76a5e4de6e659b7dbe3de6e4536bcbd25358c4688bfcc0be6941f2b41a915130fe45e6d8c0525ce57cba3a98689e9679a37441f6254e1a42dcc12c6ff99"
+
+[[distfiles]]
+name = "root-laptop-20251025_114742.ext4.zst"
+size = 1341431836
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20251025/root-laptop-20251025_114742.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "48d7207c65ee0c39106a6bcbf0cde008915d39a81890c4e73d136f84f2a705ff"
+sha512 = "4960a07a1a49b2fb7923123508150ac3dcb32e6ab83c6f40c2285b13df720ac69836445de17d810f5e054c315c22939e64e9a79bbb26c117186965779b695887"
+
+[blob]
+distfiles = [
+  "boot-laptop-20251025_114742.ext4.zst",
+  "root-laptop-20251025_114742.ext4.zst",
+]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[provisionable.partition_map]
+boot = "boot-laptop-20251025_114742.ext4"
+root = "root-laptop-20251025_114742.ext4"

--- a/manifests/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20240720.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20240720.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (16G RAM) and RevyOS 20240720"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20240720"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a-16g.bin"
+size = 1032040
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20240720/u-boot-with-spl-laptop4a-16g.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "779d2fc08e8a5a75fa3defdffc0967e6972582be9d54324f6a30b1d49072d51e"
+sha512 = "f9d5f14d4d754003791c807eade93da659e06a1ace3ca3e778153228307009d976278f318d9f0faabe65103b1b700c317c80f7ab84841abfc937bd8d203f66a6"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a-16g.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a-16g.bin"

--- a/manifests/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20250930.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20250930.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (16G RAM) and RevyOS 20250930"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250930"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a-16g.bin"
+size = 1032200
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20250930/u-boot-with-spl-laptop4a-16g.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "69fbd73fcc2a5cea62b024a6ada3e16fb9f09e7a63f693ada44553186e69e5e1"
+sha512 = "98980b46404bb91a0847e72a9613b590c7b3d82c55a19db088393e8b597e3ac4bb60637b9736c4d8dfb89a7db9d366e3fedabdb45135f21071cda4306191d2ef"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a-16g.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a-16g.bin"

--- a/manifests/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20251025.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20251025.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (16G RAM) and RevyOS 20251025"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20251025"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a-16g.bin"
+size = 1032200
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20251025/u-boot-with-spl-laptop4a-16g.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "69fbd73fcc2a5cea62b024a6ada3e16fb9f09e7a63f693ada44553186e69e5e1"
+sha512 = "98980b46404bb91a0847e72a9613b590c7b3d82c55a19db088393e8b597e3ac4bb60637b9736c4d8dfb89a7db9d366e3fedabdb45135f21071cda4306191d2ef"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a-16g.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a-16g.bin"

--- a/manifests/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20240720.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20240720.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (8G RAM) and RevyOS 20240720"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20240720"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a.bin"
+size = 1032040
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20240720/u-boot-with-spl-laptop4a.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "33ca362269c908c2693b0aa49ce00d3978c55a9fc533728cdc56de14b292286e"
+sha512 = "59827532f69e5f94fec4bf207c17a5114a60ecab566dacd825cfee8d3de0755e6a263e0f1f6a0e1fdef249c34ab1f9dffc35e2f0d93c001840dac3b82ffeb9a9"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a.bin"

--- a/manifests/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20250930.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20250930.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (8G RAM) and RevyOS 20250930"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250930"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a.bin"
+size = 1032200
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20250930/u-boot-with-spl-laptop4a.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "084b0430f3895eb6101cad13d720d55d8ba143da4112dd399ec7633b0b4e2e52"
+sha512 = "9a8573e7d25070ef77bd1a23c5918eef8e806e77f214ef0fac5ef0185a251b8c74c7705cccfd57f7393bb05512a0628d17494b3e329184f291058969638cd35f"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a.bin"

--- a/manifests/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20251025.0.toml
+++ b/manifests/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20251025.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (8G RAM) and RevyOS 20251025"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20251025"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a.bin"
+size = 1032200
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20251025/u-boot-with-spl-laptop4a.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "084b0430f3895eb6101cad13d720d55d8ba143da4112dd399ec7633b0b4e2e52"
+sha512 = "9a8573e7d25070ef77bd1a23c5918eef8e806e77f214ef0fac5ef0185a251b8c74c7705cccfd57f7393bb05512a0628d17494b3e329184f291058969638cd35f"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a.bin"


### PR DESCRIPTION
## Summary by Sourcery

Add support for Sipeed Lichee Book 4A by providing board-image and U-Boot manifests for both 8G and 16G RAM variants across RevyOS 20240720, 20250930, and 20251025, and define corresponding device, device-variant, and image-combo entities.

New Features:
- Introduce board-image manifests for Sipeed Lichee Book 4A for RevyOS versions 20240720, 20250930, and 20251025
- Add U-Boot image manifests for both 8G and 16G RAM variants of Sipeed Lichee Book 4A for RevyOS versions 20240720, 20250930, and 20251025
- Create device-variant entities for the 8G and 16G RAM variants and a device entity for the Sipeed Lichee Book 4A
- Define image-combo entities linking board-image and U-Boot packages for each RAM variant