### PR TITLE
board-images/bianbu-{desktop,minimal}-spacemit-k1: add bianbu emmc images

### DIFF
--- a/entities/image-combo/bianbu-desktop-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-desktop-spacemit-k1-emmc.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:bananapi-bpi-f3@emmc",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop for SpacemiT K1"
+package_atoms = ["board-image/bianbu-desktop-spacemit-k1"]

--- a/entities/image-combo/bianbu-minimal-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-minimal-spacemit-k1-emmc.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:bananapi-bpi-f3@emmc",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Minimal for SpacemiT K1"
+package_atoms = ["board-image/bianbu-minimal-spacemit-k1"]

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.zip"
+size = 2528985817
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0/bianbu-24.04-desktop-k1-v2.0-release-20241021195251.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c5acc94bfd783b4f008d08a92753bcc9434179dd8b6c558b3515bb0e00a855de"
+sha512 = "9370c1921ba3fd0eded3000dcf158808368ec4b74f8e6b8aba5022b6712b6d5ce77e19fd8c98fa31c071873f4f55adb57aeabbb2c81c1631bd54edfd36348c24"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.zip"
+size = 2530677868
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.1/bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "26d38f110f4def2db9e0c9356a4bcb2d25c6935d10ee9afbe68154db75221c25"
+sha512 = "69138a88e62e7039d395e0bb259fe4dcc8c80a17c249b02ad5dbdb060f07f281c395908eedba8bdd9acda06f520c5f07d570b0ebadb1d39ab404716c1ceef3a7"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.2.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.2.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.zip"
+size = 2533707834
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.2/bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "137e2ae14d77bd64fa3599826f2c2fbc3e33b9777ce8a97c550175785a54df47"
+sha512 = "92460b834d1146f93fc67874d9388dc53d9311e8c103e3c2fe66d665a3e3d21212f9ca0b43c290a3a4f291f664f3891852d02d6d3cb360dccea3e410b53a0ae7"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.4.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.0.4.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.4 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.4"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.zip"
+size = 2632524044
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.4/bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "70e4c6a23b18686ad86d9b4ea5b3602ef3efa594901d1abaa74325704b7b0b6e"
+sha512 = "fd26f6b3b261f7ce55f2f66c6ad4442cdb7a948a00dfecfd3e433ad18d8157ca062bbbd420536f2f345a7054a133bd33ef8720cb82236e3c9c4feb8e1b8afc2d"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.1.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.1.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.zip"
+size = 2615638690
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1/bianbu-24.04-desktop-k1-v2.1-release-20250124144655.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b237bb5610ab5cca16a4534f3e6889c9fcff08009dc5e1e150c7a8e32afe92cf"
+sha512 = "8b361252336e6f07abdf4a290d79b99750291964515fdf8d16d01054f743ba2e797d3eaaee595a638fc7943aa88570b17b8832cfaff6f51ee56c683bd2bbaa72"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.1.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.1.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.zip"
+size = 2616261133
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "3da3a0d632330618f705a94c92ff6d4cff724b8eb9ccea65218d447a91cac3bd"
+sha512 = "70415ade40571ec9209fb69f6d039e3e1f1b5cc38b8ba5db8a4b035f7256bbd0cb0cfe85a1c7b5b5f52dc90925ca9c46117a191d4817cfc0ee00ce7e8eef7b67"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.1.2.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.1.2.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.zip"
+size = 2575115597
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.2/bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "151ef10d7a162e80cf0d91db5dc70953bba33edc406de866afc00941e49a2fee"
+sha512 = "fd11323e1c61013671911452f7002f4dc0e3d5aa5bc0a2af6f55de6f0c3224e5e12d9b511c5bac920df84853a31555b50dd2339b87a8bfebeed6cb1ea7b98573"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.2.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.2.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.zip"
+size = 2639790326
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2/bianbu-24.04-desktop-k1-v2.2-release-20250430190125.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "57dc320094c6b4e427ab40b39b4419cb5a6080fd913c63db8ccd56eba244bf0b"
+sha512 = "5049de37bc91f1dfbb635b3bf470d03f4655829232d3a57c54a263efb9579d345733acaa1c2e3357bf2f48f0300cc1273bafc5aabe369daa15e6f15e58d7a1f8"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/2.2.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/2.2.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.2.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.zip"
+size = 2644972721
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2.1/bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "9d7d61fc86075625c9196ffc697a69af34e23d61c01ba4ebe7f7ef5c2d6e82ad"
+sha512 = "7aa14d7e823f0af12a25bc8c835723feb923763cf27da055f2376b25224fe0d13f6a05858722a542c51e53d7842f3abe9c4ca6632884d100747e30461aaaf5a3"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/3.0.0.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/3.0.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v3.0 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.zip"
+size = 2596798751
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0/bianbu-25.04-desktop-k1-v3.0-release-20250725125828.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "2a81576b480716f371a704a77912f27954d89ff2ef2f3907c6ff839f28769094"
+sha512 = "5221355686728b27de6146fb3f5f58065168239e910c8b06d10f984744d788aeb7923b436dc6debdac45bc492f29861dbfd845ec0cde6d427aff84bdd53f1ca1"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-spacemit-k1/3.0.1.toml
+++ b/manifests/board-image/bianbu-desktop-spacemit-k1/3.0.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v3.0.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0.1"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.zip"
+size = 2601164447
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0.1/bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7741ed172743d8b6b9cf31594353df7188e0a07ba8f8fb70b0a85007276e9143"
+sha512 = "26af574cadd9c1ad82cfdd46b77ca5c97fc5c3b04c1a5b3854fd994ab85f61ae06bd336eddab9041edd08bcb81d8dc99228d962d4bf485aa4a74d307f3756014"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.zip"
+size = 2528985817
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0/bianbu-24.04-desktop-k1-v2.0-release-20241021195251.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c5acc94bfd783b4f008d08a92753bcc9434179dd8b6c558b3515bb0e00a855de"
+sha512 = "9370c1921ba3fd0eded3000dcf158808368ec4b74f8e6b8aba5022b6712b6d5ce77e19fd8c98fa31c071873f4f55adb57aeabbb2c81c1631bd54edfd36348c24"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0-release-20241021195251.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.zip"
+size = 2530677868
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.1/bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "26d38f110f4def2db9e0c9356a4bcb2d25c6935d10ee9afbe68154db75221c25"
+sha512 = "69138a88e62e7039d395e0bb259fe4dcc8c80a17c249b02ad5dbdb060f07f281c395908eedba8bdd9acda06f520c5f07d570b0ebadb1d39ab404716c1ceef3a7"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.1-release-20241025234454.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.2.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.2.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.zip"
+size = 2533707834
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.2/bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "137e2ae14d77bd64fa3599826f2c2fbc3e33b9777ce8a97c550175785a54df47"
+sha512 = "92460b834d1146f93fc67874d9388dc53d9311e8c103e3c2fe66d665a3e3d21212f9ca0b43c290a3a4f291f664f3891852d02d6d3cb360dccea3e410b53a0ae7"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.2-release-20241111222735.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.4.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.0.4.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.0.4 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.0.4"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.zip"
+size = 2632524044
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.0.4/bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "70e4c6a23b18686ad86d9b4ea5b3602ef3efa594901d1abaa74325704b7b0b6e"
+sha512 = "fd26f6b3b261f7ce55f2f66c6ad4442cdb7a948a00dfecfd3e433ad18d8157ca062bbbd420536f2f345a7054a133bd33ef8720cb82236e3c9c4feb8e1b8afc2d"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.0.4-release-20241206002355.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.1.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.1.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.zip"
+size = 2615638690
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1/bianbu-24.04-desktop-k1-v2.1-release-20250124144655.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b237bb5610ab5cca16a4534f3e6889c9fcff08009dc5e1e150c7a8e32afe92cf"
+sha512 = "8b361252336e6f07abdf4a290d79b99750291964515fdf8d16d01054f743ba2e797d3eaaee595a638fc7943aa88570b17b8832cfaff6f51ee56c683bd2bbaa72"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1-release-20250124144655.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.1.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.1.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.zip"
+size = 2616261133
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.1/bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "3da3a0d632330618f705a94c92ff6d4cff724b8eb9ccea65218d447a91cac3bd"
+sha512 = "70415ade40571ec9209fb69f6d039e3e1f1b5cc38b8ba5db8a4b035f7256bbd0cb0cfe85a1c7b5b5f52dc90925ca9c46117a191d4817cfc0ee00ce7e8eef7b67"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1.1-release-20250305144026.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.1.2.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.1.2.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.1.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.1.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.zip"
+size = 2575115597
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.1.2/bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "151ef10d7a162e80cf0d91db5dc70953bba33edc406de866afc00941e49a2fee"
+sha512 = "fd11323e1c61013671911452f7002f4dc0e3d5aa5bc0a2af6f55de6f0c3224e5e12d9b511c5bac920df84853a31555b50dd2339b87a8bfebeed6cb1ea7b98573"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.1.2-release-20250421172038.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.2.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.2.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.zip"
+size = 2639790326
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2/bianbu-24.04-desktop-k1-v2.2-release-20250430190125.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "57dc320094c6b4e427ab40b39b4419cb5a6080fd913c63db8ccd56eba244bf0b"
+sha512 = "5049de37bc91f1dfbb635b3bf470d03f4655829232d3a57c54a263efb9579d345733acaa1c2e3357bf2f48f0300cc1273bafc5aabe369daa15e6f15e58d7a1f8"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.2-release-20250430190125.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/2.2.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/2.2.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.2.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.zip"
+size = 2644972721
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2.1/bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "9d7d61fc86075625c9196ffc697a69af34e23d61c01ba4ebe7f7ef5c2d6e82ad"
+sha512 = "7aa14d7e823f0af12a25bc8c835723feb923763cf27da055f2376b25224fe0d13f6a05858722a542c51e53d7842f3abe9c4ca6632884d100747e30461aaaf5a3"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-k1-v2.2.1-release-20250815220536.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/3.0.0.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/3.0.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v3.0 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.zip"
+size = 2596798751
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0/bianbu-25.04-desktop-k1-v3.0-release-20250725125828.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "2a81576b480716f371a704a77912f27954d89ff2ef2f3907c6ff839f28769094"
+sha512 = "5221355686728b27de6146fb3f5f58065168239e910c8b06d10f984744d788aeb7923b436dc6debdac45bc492f29861dbfd845ec0cde6d427aff84bdd53f1ca1"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-k1-v3.0-release-20250725125828.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-minimal-spacemit-k1/3.0.1.toml
+++ b/manifests/board-image/bianbu-minimal-spacemit-k1/3.0.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v3.0.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0.1"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.zip"
+size = 2601164447
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0.1/bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7741ed172743d8b6b9cf31594353df7188e0a07ba8f8fb70b0a85007276e9143"
+sha512 = "26af574cadd9c1ad82cfdd46b77ca5c97fc5c3b04c1a5b3854fd994ab85f61ae06bd336eddab9041edd08bcb81d8dc99228d962d4bf485aa4a74d307f3756014"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-k1-v3.0.1-release-20250815185656.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"


### PR DESCRIPTION
## Summary by Sourcery

Add support for Bianbu Desktop and Minimal Ubuntu images on SpacemiT K1 eMMC by including manifests for multiple upstream versions and defining image-combo entities for provisioning.

New Features:
- Add versioned manifests for Bianbu Desktop images (v2.0.0 through v3.0.1) targeting SpacemiT K1
- Add versioned manifests for Bianbu Minimal images (v2.0.0 through v3.0.1) targeting SpacemiT K1
- Introduce image-combo entities for eMMC provisioning of both Desktop and Minimal Bianbu images on SpacemiT K1