### PR TITLE
entities: new device MilkV Jupiter

### DIFF
--- a/entities/device/milkv-jupiter.toml
+++ b/entities/device/milkv-jupiter.toml
@@ -1,0 +1,11 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:bananapi-bpi-f3@sd",
+  "device-variant:bananapi-bpi-f3@emmc",
+]
+unique_among_type_during_traversal = true
+
+[device]
+id = "milkv-jupiter"
+display_name = "Milk-V Jupiter"


### PR DESCRIPTION
I don't have this board, so I don't know whether these images works well on MilkV Jupiter. But [support-matrix](https://github.com/ruyisdk/support-matrix/tree/4765dc8270ffc56cf0967e909411a01496b2db12/Jupiter/Bianbu) says that they work well.

## Summary by Sourcery

New Features:
- Introduce Milk-V Jupiter device entity configuration linking it to the Bananapi BPI-F3 SD and eMMC variants