### PR TITLE
board-images/bianbu-desktop-lite-spacemit-{k1,k1-sd}: add bianbu desktop lite images

### DIFF
--- a/entities/image-combo/bianbu-desktop-lite-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-desktop-lite-spacemit-k1-emmc.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:bananapi-bpi-f3@emmc",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop Lite for SpacemiT K1/M1"
+package_atoms = ["board-image/bianbu-desktop-lite-spacemit-k1"]

--- a/entities/image-combo/bianbu-desktop-lite-spacemit-k1-sd.toml
+++ b/entities/image-combo/bianbu-desktop-lite-spacemit-k1-sd.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:bananapi-bpi-f3@sd",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop Lite for SpacemiT K1/M1"
+package_atoms = ["board-image/bianbu-desktop-lite-spacemit-k1-sd"]

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/2.2.0.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/2.2.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.img.zip"
+size = 1867535805
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2/bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c533c5681a198c949942e9198f48047cea3dc0d92ec777ee19b722416149dada"
+sha512 = "bd36335fb46f082fed7a1859f21ad7ebbb003be4fa1a49ef45595ae7d5c27de3515a6781b25dfb6a569b7c361a6a22b45aaa6403994bed7dc31f91f45d754599"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.img"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/2.2.1.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/2.2.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.2.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.img.zip"
+size = 2070040587
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2.1/bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c15f58f70a4e3d40d29955295bba340a90781d7da10ed49e5eee7946106514f2"
+sha512 = "1a87b4e66036d66c22f06265853091c869c6032783e4fa5d5e5da1e5badf8ec6cc27b30fb1a27864a922694c43a91c95ff8d87201b3eec79c1a06fabb3deb5af"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.img"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/3.0.0.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/3.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v3.0 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.img.zip"
+size = 2011036411
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0/bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "9679139db76fcc02447b4f02f0abb65f58f9b23306c0446b2d518ded8b133c05"
+sha512 = "3fd5938212c87595d1fd0205efab27e2b645d10dd3f4b567e55cc79106047a494621844fbfa8e1de403ec2944da2b5f0a74da184a3beb2b6bd4f79f4a31eb6dd"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.img"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/3.0.1.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1-sd/3.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v3.0.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0.1"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.img.zip"
+size = 2015524307
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0.1/bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "99c0926bd7bd0f74130a8ce4f1ce01cb03b06f19dd6da63f64f5b2b7745bfaeb"
+sha512 = "6e76f0dab81151ff91091925bea0ec3b586b41d2e97df4d2480c153d83b2c804a950fb30e4a9344012fb4efdbab944888588d54ee248c721e256e12630f33928"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.img"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1/2.2.0.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1/2.2.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.2 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.zip"
+size = 1867534799
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2/bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d468ef4304035d318a334307b041c3eaa83e20bc8a13c03e400a423c24da2f59"
+sha512 = "7a77f0b55f5d02420a5739c8ebd378d99d4b514e1f419f9533c27a66b1543c322a69d6f06fd52b9ec4ed3d90e7329d27f62102a7a3fc2de333156337e9327218"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-lite-k1-v2.2-release-20250430185050.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1/2.2.1.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1/2.2.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.2.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.2.1"
+
+[[distfiles]]
+name = "bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.zip"
+size = 2070036074
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.2.1/bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "78e38f60a68f1e24bbe5db92dfbd10fa2c0e2397e4a2deaff45a90f5201c1ca3"
+sha512 = "f8a80f3b2268b368de295b57a3b7ab71c4ddb9b72ac385c6ce5b46d1b8fac60c7850628871d2a2d8ab0d04371a6275e232cad4c8bbc523292fb5ec3b66529e82"
+
+[blob]
+distfiles = [
+  "bianbu-24.04-desktop-lite-k1-v2.2.1-release-20250815215854.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1/3.0.0.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1/3.0.0.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v3.0 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.zip"
+size = 2011046621
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0/bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "cb48f824ee3053b6ee9160ced43cce0db9195b8435ca929692628700e28e961f"
+sha512 = "d6785f6abc5814025f61ec2963ae2062847578ddfa425314dc9e90696c96deff2655676fcc2c74a876252226b30efda48829b23869b81d2611127e6b33b67b84"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-lite-k1-v3.0-release-20250725124256.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/manifests/board-image/bianbu-desktop-lite-spacemit-k1/3.0.1.toml
+++ b/manifests/board-image/bianbu-desktop-lite-spacemit-k1/3.0.1.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v3.0.1 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v3.0.1"
+
+[[distfiles]]
+name = "bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.zip"
+size = 2015510957
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v3.0.1/bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d1cb60c194e024ded0908ac9ff67e60608995d572d2b8c1642e997e7fb034de7"
+sha512 = "429eae4ed2c30884be681d2a0d987dfb1f76ddf62116a16544b4f9f49c94a3ad55650bf7dc7ff80cf0912435f0dcead03a28177bfe8a2ea490cb6c745265ece2"
+
+[blob]
+distfiles = [
+  "bianbu-25.04-desktop-lite-k1-v3.0.1-release-20250815184229.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"


### PR DESCRIPTION
## Summary by Sourcery

Add official Bianbu Desktop Lite v2.2.0, v2.2.1, v3.0.0, and v3.0.1 board images for SpacemiT K1 with both eMMC and SD provisioning strategies, and register corresponding image combos for K1/M1 devices.

New Features:
- Add board-image manifests for Bianbu Desktop Lite v2.2.0, v2.2.1, v3.0.0, and v3.0.1 on SpacemiT K1 using the spacemit-k1-v1 (eMMC) strategy
- Add board-image manifests for Bianbu Desktop Lite v2.2.0, v2.2.1, v3.0.0, and v3.0.1 on SpacemiT K1 using the dd-v1 (SD) strategy
- Introduce image-combo entities to group the eMMC and SD variants of Bianbu Desktop Lite for SpacemiT K1/M1