### PR TITLE
entities: new device MilkV Megrez support

### DIFF
--- a/entities/device-variant/milkv-megrez@generic.toml
+++ b/entities/device-variant/milkv-megrez@generic.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:sifive-p550"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "generic"
+variant_name = "generic variant"

--- a/entities/device/milkv-megrez.toml
+++ b/entities/device/milkv-megrez.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:milkv-megrez@generic",
+]
+unique_among_type_during_traversal = true
+
+[device]
+id = "milkv-megrez"
+display_name = "Milk-V Megrez"

--- a/entities/image-combo/rockos-milkv-megrez.toml
+++ b/entities/image-combo/rockos-milkv-megrez.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:milkv-megrez@generic",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "RedleafOS for MilkV Megrez"
+package_atoms = ["board-image/rockos-milkv-megrez"]

--- a/entities/uarch/sifive-p550.toml
+++ b/entities/uarch/sifive-p550.toml
@@ -1,0 +1,13 @@
+ruyi-entity = "v0"
+
+related = ["arch:riscv64"]
+unique_among_type_during_traversal = true
+
+[uarch]
+id = "sifive-p550"
+display_name = "SiFive P550"
+arch = "riscv64"
+
+[uarch.riscv]
+# RockOS cat /proc/cpuinfo
+isa = "rv64imafdch_zicntr_zicsr_zifencei_zihpm_zba_zbb_sscofpmf"

--- a/manifests/board-image/rockos-milkv-megrez/0.20250117.0.toml
+++ b/manifests/board-image/rockos-milkv-megrez/0.20250117.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RockOS 20241230_20250117 image for Milk-V Megrez with EIC7700"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20241230_20250117"
+
+[[distfiles]]
+name = "sdcard-rockos-20250117-223529.img.zst"
+size = 2564076810
+urls = [
+  "https://mirror.iscas.ac.cn/rockos/images/generic/20241230_20250117/sdcard-rockos-20250117-223529.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "bccd4dacc00f97d4958f5c1f5cea6b78d8614b7c5eff1bc02d929c4f462d081c"
+sha512 = "c6cffc7c71d1a148feb3d9c60222f99c34eb5ce2d1a87188fd709c5fdefc88957efe50793372b9792abce01966f83d8391fe21a832ec157cac054fd43d43f65e"
+
+[blob]
+distfiles = [
+  "sdcard-rockos-20250117-223529.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "sdcard-rockos-20250117-223529.img"

--- a/manifests/board-image/rockos-milkv-megrez/0.20250123.0.toml
+++ b/manifests/board-image/rockos-milkv-megrez/0.20250123.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RockOS 20241230_20250124 image for Milk-V Megrez with EIC7700"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20241230_20250124"
+
+[[distfiles]]
+name = "sdcard-rockos-20250123-210346.img.zst"
+size = 2593414846
+urls = [
+  "https://mirror.iscas.ac.cn/rockos/images/generic/20241230_20250124/sdcard-rockos-20250123-210346.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b364ed826a1caf1e996f6aab8f6d5759b061a135c15ee3653d5883c50fd522d1"
+sha512 = "b4c9e6b95e65d799116e26b2ad0e05128b82a09d09643d772253c45dfbce20382aa83f8856accf912c3e6fc69a137c29711fa4869da398ef21c6ede2de4dd644"
+
+[blob]
+distfiles = [
+  "sdcard-rockos-20250123-210346.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "sdcard-rockos-20250123-210346.img"

--- a/manifests/board-image/rockos-milkv-megrez/0.20250219.0.toml
+++ b/manifests/board-image/rockos-milkv-megrez/0.20250219.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RockOS 20250130_20250219 image for Milk-V Megrez with EIC7700"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250130_20250219"
+
+[[distfiles]]
+name = "sdcard-rockos-20250219-091803.img.zst"
+size = 2640132503
+urls = [
+  "https://mirror.iscas.ac.cn/rockos/images/generic/20250130_20250219/sdcard-rockos-20250219-091803.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "8d179a046f190c51a8bc97246f9dc5fe5183c5f599d6f327e7d7a18b83e12fb8"
+sha512 = "d717e70fd18209ff9ec056ad8e6006f146f7204ed6e20e2664581ab705ed205c84ef898bacb2d4bcf97fb521f5a92f3993e7115d7ee0d0ba9f62b69f9e4840f5"
+
+[blob]
+distfiles = [
+  "sdcard-rockos-20250219-091803.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "sdcard-rockos-20250219-091803.img"

--- a/manifests/board-image/rockos-milkv-megrez/0.20250423.0.toml
+++ b/manifests/board-image/rockos-milkv-megrez/0.20250423.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RockOS 20250330_20250423 image for Milk-V Megrez with EIC7700"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250330_20250423"
+
+[[distfiles]]
+name = "sdcard-rockos-20250423-145338.img.zst"
+size = 2623463396
+urls = [
+  "https://mirror.iscas.ac.cn/rockos/images/generic/20250330_20250423/sdcard-rockos-20250423-145338.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c5bae1cb077c02934fb3b2544e54c7872371275474cdc87828b1ebb0f74ee81b"
+sha512 = "310bd2f98e6b0322b85a8d66c63cbd76cdb3a8df912d6503e916f66e6e6a755b1ec589c5880d30d54c73bd6d78722eac36803d3f9d95b74ce1f81ecddd99f63f"
+
+[blob]
+distfiles = [
+  "sdcard-rockos-20250423-145338.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "sdcard-rockos-20250423-145338.img"

--- a/manifests/board-image/rockos-milkv-megrez/0.20250729.0.toml
+++ b/manifests/board-image/rockos-milkv-megrez/0.20250729.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RockOS 20250530_20250729 image for Milk-V Megrez with EIC7700"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250530_20250729"
+
+[[distfiles]]
+name = "sdcard-rockos-20250729-015830.img.zst"
+size = 2592843420
+urls = [
+  "https://mirror.iscas.ac.cn/rockos/images/generic/20250530_20250729/sdcard-rockos-20250729-015830.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c1595812ade462a68c88c473f5672400a4c2906f75b6f4c4e23d58140b139e49"
+sha512 = "8d22a99f1b406ce7f0db7ae21b868d23d9c85e418f3c86dbdb987069d9945d3324e609737e911752faa557c85938eeb8e97e667aad502c163dd26fd64c60c386"
+
+[blob]
+distfiles = [
+  "sdcard-rockos-20250729-015830.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "sdcard-rockos-20250729-015830.img"

--- a/manifests/board-image/rockos-milkv-megrez/0.20250818.0.toml
+++ b/manifests/board-image/rockos-milkv-megrez/0.20250818.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RockOS 20250630_20250818 image for Milk-V Megrez with EIC7700"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250630_20250818"
+
+[[distfiles]]
+name = "sdcard-rockos-20250818-234921.img.zst"
+size = 2620924052
+urls = [
+  "https://mirror.iscas.ac.cn/rockos/images/generic/20250630_20250818/sdcard-rockos-20250818-234921.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "faa463fe559aeacd8ac6425efdfaeb084b713aba22df4e2be0bca0256be86a53"
+sha512 = "71710a922c2494200f664805257d775ccba638112d4f015208b7d8be19df77fc8ad8302dd889f09cfdb1359ffe8f2666de50b35a53c93bfc5453ac47795b9db6"
+
+[blob]
+distfiles = [
+  "sdcard-rockos-20250818-234921.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "sdcard-rockos-20250818-234921.img"


### PR DESCRIPTION
I'm still not quite sure about the uarch of P550 yet.

The RockOS is tested on my own Megrez.

## Summary by Sourcery

Introduce support for the Milk-V Megrez device by defining its entity and generic variant, adding an image-combo, and providing monthly RockOS board-image manifests for provisioning.

New Features:
- Add Milk-V Megrez device entity and generic variant
- Add RockOS for MilkV Megrez image-combo entity

Enhancements:
- Introduce board-image manifests for RockOS snapshots for Milk-V Megrez (20250117 through 20250818)

## Summary by Sourcery

Add support for the Milk-V Megrez board and its RockOS images.

New Features:
- Introduce a SiFive P550 microarchitecture entity used by Milk-V Megrez.
- Add Milk-V Megrez device and generic device-variant entities.
- Define a RockOS image-combo entity for Milk-V Megrez with associated board-image package manifests.

Enhancements:
- Provide RockOS board-image manifests for Milk-V Megrez snapshots from 2025-01-17 through 2025-08-18, including provisioning metadata.