### PR TITLE
entities: new device Xiangshan Nanhu Laptop support

### DIFF
--- a/entities/device-variant/xiangshan-nanhu@generic.toml
+++ b/entities/device-variant/xiangshan-nanhu@generic.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:xiangshan-nanhu"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "generic"
+variant_name = "generic variant"

--- a/entities/device/xiangshan-nanhu-laptop.toml
+++ b/entities/device/xiangshan-nanhu-laptop.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:xiangshan-nanhu@generic",
+]
+unique_among_type_during_traversal = true
+
+[device]
+id = "xiangshan-nanhu-laptop"
+display_name = "Xiangshan Nanhu Laptop"

--- a/entities/image-combo/redleafos-xiangshan-nanhu.toml
+++ b/entities/image-combo/redleafos-xiangshan-nanhu.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:xiangshan-nanhu@generic",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "RedleafOS for Xiangshan Nanhu"
+package_atoms = ["board-image/redleafos-xiangshan-nanhu"]

--- a/manifests/board-image/redleafos-xiangshan-nanhu/0.20250113.0.toml
+++ b/manifests/board-image/redleafos-xiangshan-nanhu/0.20250113.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RedleafOS 20250113 image for Xiangshan Nanhu"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250113"
+
+[[distfiles]]
+name = "debian-nanhu-20250113-113430.img.zst"
+size = 1580537401
+urls = [
+  "https://mirror.iscas.ac.cn/redleafos/extra/images/20250113/debian-nanhu-20250113-113430.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "3df2266e7115c94f38cabec9e70d4176111b5acc7bc6e05aef37dfd17824a5eb"
+sha512 = "9b6dcc710d2a13d302700d23706ad3a986f9edf623baade01141231201f4ddcd79fa378f092cce4c860f72c93a4537a2c400296cdf9817f2e0f31aa937a2b68f"
+
+[blob]
+distfiles = [
+  "debian-nanhu-20250113-113430.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "debian-nanhu-20250113-113430.img"

--- a/manifests/board-image/redleafos-xiangshan-nanhu/0.20250922.0.toml
+++ b/manifests/board-image/redleafos-xiangshan-nanhu/0.20250922.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RedleafOS 20250922 image for Xiangshan Nanhu"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250922"
+
+[[distfiles]]
+name = "debian-nanhuv2-20250922-155014.img.zst"
+size = 1381711863
+urls = [
+  "https://mirror.iscas.ac.cn/redleafos/extra/images/20250922/debian-nanhuv2-20250922-155014.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "75adf6ff17b7a87c0bc0211db992c24d46a414a0281806eb5190dd653df82505"
+sha512 = "2054a2b04d09162e4fe06df6fa6ba7a9ef36f4fe2ebd3af6532087079d1e194df15c08b69c8d2d2acb74b7c875ef8568c4480ea046340781ad23aad993c82f54"
+
+[blob]
+distfiles = [
+  "debian-nanhuv2-20250922-155014.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "debian-nanhuv2-20250922-155014.img"

--- a/manifests/board-image/redleafos-xiangshan-nanhu/0.20250927.0.toml
+++ b/manifests/board-image/redleafos-xiangshan-nanhu/0.20250927.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RedleafOS 20250927 image for Xiangshan Nanhu"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20250927"
+
+[[distfiles]]
+name = "debian-nanhuv2-20250927-224931.img.zst"
+size = 1505349297
+urls = [
+  "https://mirror.iscas.ac.cn/redleafos/extra/images/20250927/debian-nanhuv2-20250927-224931.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1cf5c0df24260ab4feefb48b00d683e2e86fd61ef15289e660a21b71b2b880e1"
+sha512 = "9e704908acdd0abbb06c24d7a6079f492721a722eb0c5b568a83cd256f8b5890a1cb99c011c16226f2fcf3322d71cbbb06ad4f97d9c0028b3f82ba9be677a9a6"
+
+[blob]
+distfiles = [
+  "debian-nanhuv2-20250927-224931.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "debian-nanhuv2-20250927-224931.img"


### PR DESCRIPTION
I'm not sure about naming of this device.

## Summary by Sourcery

Add initial support for the Xiangshan Nanhu Laptop device by defining its device and variant entities, provisioning image-combo, and including three RedleafOS board-image manifests for the corresponding releases.

New Features:
- Introduce support for Xiangshan Nanhu Laptop by adding device and generic variant entities
- Add board-image manifests for RedleafOS on Xiangshan Nanhu for 20250113, 20250922, and 20250927 releases
- Add image-combo entity for RedleafOS Xiangshan Nanhu