### PR TITLE
board-image/openbsd-riscv64-live: bump to latest version 7.8

### DIFF
--- a/manifests/board-image/openbsd-riscv64-live/7.8.0.toml
+++ b/manifests/board-image/openbsd-riscv64-live/7.8.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official OpenBSD 7.8 riscv64 live image"
+vendor = { name = "OpenBSD", eula = "" }
+upstream_version = "7.8"
+
+[[distfiles]]
+name = "install78.img"
+size = 528482304
+urls = [
+  "mirror://openbsd/7.8/riscv64/install78.img",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "866742226f967bcb91be75eca48b55b7a042a5965d71ed759d84b96d3fb6ebd1"
+sha512 = "6d49e32ab9f58c4b1e8659c9051e423db79a71879c6b20b2dcdda17a0eeb50bb00c9da633d0b23525d04fad4980eeab162ba80ab6d9b9dab8b8e68ad18ba00b3"
+
+[blob]
+distfiles = [
+  "install78.img",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+live = "install78.img"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a board-image manifest for the OpenBSD 7.8 riscv64 live install image.