### PR TITLE
board-image/freebsd-riscv64-mini-live: bump to latest version 15.0

### DIFF
--- a/manifests/board-image/freebsd-riscv64-mini-live/15.0.0.toml
+++ b/manifests/board-image/freebsd-riscv64-mini-live/15.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official FreeBSD 15.0 RELEASE riscv64 live image"
+vendor = { name = "FreeBSD", eula = "" }
+upstream_version = "15.0"
+
+[[distfiles]]
+name = "FreeBSD-15.0-RELEASE-riscv-riscv64-mini-memstick.img"
+size = 795555328
+urls = [
+  "mirror://freebsd-releases/riscv/riscv64/ISO-IMAGES/15.0/FreeBSD-15.0-RELEASE-riscv-riscv64-mini-memstick.img",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "0c7415dfcffdc2c297c0494ebc66d75be4927b9e327a72b94fa9393edf4a931d"
+sha512 = "f34489186898e4eefb642ab90cdef848f5d57ad27339f05a0baff922effac608dba4c1afdeb54c3a4592b5d3c1a95ecd428781126de281a84396dd2ba01e91e9"
+
+[blob]
+distfiles = [
+  "FreeBSD-15.0-RELEASE-riscv-riscv64-mini-memstick.img",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+live = "FreeBSD-15.0-RELEASE-riscv-riscv64-mini-memstick.img"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a 15.0.0 manifest for the FreeBSD riscv64 mini live image with associated metadata, download details, and provisioning configuration.