### PR TITLE
board-image/openwrt-sifive-unmatched: bump to latest version 24.10.4

### DIFF
--- a/manifests/board-image/openwrt-sifive-unmatched/0.2410.3.toml
+++ b/manifests/board-image/openwrt-sifive-unmatched/0.2410.3.toml
@@ -1,0 +1,30 @@
+format = "v1"
+
+[metadata]
+desc = "Official OpenWRT 24.10.3 image for SiFive Unmatched"
+vendor = { name = "OpenWrt", eula = "" }
+upstream_version = "24.10.3"
+
+[[distfiles]]
+name = "openwrt-24.10.3-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz"
+size = 9369469
+urls = [
+  "https://mirrors.tuna.tsinghua.edu.cn/openwrt/releases/24.10.3/targets/sifiveu/generic/openwrt-24.10.3-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+  "https://downloads.openwrt.org/releases/24.10.3/targets/sifiveu/generic/openwrt-24.10.3-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "e186227479e325122246c82bb3ca7df3e73997fd5973056f2e8272a235df888e"
+sha512 = "97397ebe803b0e0347052d231890f2cf7a402ddc53a7333994ef3ffefaf0733ac5332f316a53ef332597ab47700cc57fbe4f034b48e368b56f36192da7b036c3"
+
+[blob]
+distfiles = [
+  "openwrt-24.10.3-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "openwrt-24.10.3-sifiveu-generic-sifive_unmatched-ext4-sdcard.img"

--- a/manifests/board-image/openwrt-sifive-unmatched/0.2410.4.toml
+++ b/manifests/board-image/openwrt-sifive-unmatched/0.2410.4.toml
@@ -1,0 +1,30 @@
+format = "v1"
+
+[metadata]
+desc = "Official OpenWRT 24.10.4 image for SiFive Unmatched"
+vendor = { name = "OpenWrt", eula = "" }
+upstream_version = "24.10.4"
+
+[[distfiles]]
+name = "openwrt-24.10.4-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz"
+size = 9376065
+urls = [
+  "https://mirrors.tuna.tsinghua.edu.cn/openwrt/releases/24.10.4/targets/sifiveu/generic/openwrt-24.10.4-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+  "https://downloads.openwrt.org/releases/24.10.4/targets/sifiveu/generic/openwrt-24.10.4-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "29e751aba2e382189dfc28dc92526764e2167d5d6c1d8c56a2b526f84257cd5c"
+sha512 = "1ea1910a8b70d8d8c8cdc7f2564db0ff8b77c873a3a1144bea883bb1c060e796e369164b00359c24cce2240e11431e4e2f7d7391d763ffbdcc7e88ed71350c14"
+
+[blob]
+distfiles = [
+  "openwrt-24.10.4-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "openwrt-24.10.4-sifiveu-generic-sifive_unmatched-ext4-sdcard.img"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce manifests for OpenWrt 24.10.3 and 24.10.4 SiFive Unmatched SD card images, including metadata, download locations, and checksums for provisioning.