### PR TITLE
board-image/revyos-sipeed-pioneer: bump to latest version 20251115

### DIFF
--- a/manifests/board-image/revyos-milkv-pioneer/0.20251115.0.toml
+++ b/manifests/board-image/revyos-milkv-pioneer/0.20251115.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20251115 image for Milk-V Pioneer Box with SG2042"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20251115"
+
+[[distfiles]]
+name = "revyos-pioneer-20251115-205927.img.zst"
+size = 3388897126
+urls = [
+  "mirror://revyos/extra/images/sg2042/20251115/revyos-pioneer-20251115-205927.img.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "183504d1404f31e97cebcd8830cf15b77d394b596e82df1428685a4356ac3975"
+sha512 = "32c78fdaac2b0b8791b7e224cc7b21314346c554673be87f71120ac48aadfd90ca605932e189f1076d299a8a3144bfb22cfb82ba5d76e8017fc44ca0cc687b89"
+
+[blob]
+distfiles = [
+  "revyos-pioneer-20251115-205927.img.zst",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "revyos-pioneer-20251115-205927.img"


### PR DESCRIPTION
## Summary by Sourcery

Add manifest for the latest RevyOS image release for the Milk-V Pioneer Box SG2042 board.

New Features:
- Introduce a new board-image manifest for RevyOS 20251115 on Milk-V Pioneer Box with SG2042 hardware.

Chores:
- Record image metadata, download location, checksums, and provisioning configuration for the new RevyOS Pioneer image build.