### PR TITLE
board-image/buildroot-sdk-sipeed-licheervnano: bump to latest version 20251202

### DIFF
--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20251202.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20251202.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20251202"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20251202"
+
+[[distfiles]]
+name = "2025-12-02-16-54-27b96a.img.xz"
+size = 171132160
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20251202/2025-12-02-16-54-27b96a.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "0fd8c339ba7dfe5baa559ffdd3b6edf1691054c863e3e2ec695fdc640d32fcda"
+sha512 = "1947f9d1a0c92b4231416c72de8cf7e610d92866374c81209091d5896f5f7f0ba291949d74e4e66abe3d71ca8974f256a44e81b0faa5116810e451e17cf371fb"
+
+[blob]
+distfiles = [
+  "2025-12-02-16-54-27b96a.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-12-02-16-54-27b96a.img"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a new board-image manifest version 0.20251202.0 for the Sipeed LicheeRV Nano Buildroot SDK and FreeRTOS image.