### PR TITLE
board-image/buildroot-sdk-sipeed-licheervnano: bump to version 20251230

### DIFF
--- a/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20251230.0.toml
+++ b/manifests/board-image/buildroot-sdk-sipeed-licheervnano/0.20251230.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Buildroot SDK & FreeRTOS image for Sipeed LicheeRV Nano, 20251230"
+vendor = { name = "Sipeed", eula = "" }
+upstream_version = "20251230"
+
+[[distfiles]]
+name = "2025-12-30-20-00-6073d5.img.xz"
+size = 165524952
+urls = [
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20251230/2025-12-30-20-00-6073d5.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "aba5199e4a4d3577221476462a86d890e902a80182070998410965ac655b31a7"
+sha512 = "b2f159f7671380df25e85b3a8cff560f977b1e47392393d68f46b94b2c4309b5091da2bd8fd117f7337a1b9c32e4124f52eb8088b5430c8e0f3fcba4aa024d75"
+
+[blob]
+distfiles = [
+  "2025-12-30-20-00-6073d5.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "2025-12-30-20-00-6073d5.img"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a 20251230 versioned image manifest for the Sipeed LicheeRV Nano Buildroot SDK and FreeRTOS image.