### PR TITLE
Update openwrt-sifiveu to 0.2410.5

### DIFF
--- a/manifests/board-image/openwrt-sifive-unmatched/0.2410.5.toml
+++ b/manifests/board-image/openwrt-sifive-unmatched/0.2410.5.toml
@@ -1,0 +1,30 @@
+format = "v1"
+
+[metadata]
+desc = "Official OpenWRT 24.10.5 image for SiFive Unmatched"
+vendor = { name = "OpenWrt", eula = "" }
+upstream_version = "24.10.5"
+
+[[distfiles]]
+name = "openwrt-24.10.5-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz"
+size = 9384937
+urls = [
+  "https://mirrors.tuna.tsinghua.edu.cn/openwrt/releases/24.10.5/targets/sifiveu/generic/openwrt-24.10.5-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+  "https://downloads.openwrt.org/releases/24.10.5/targets/sifiveu/generic/openwrt-24.10.5-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "c5d1da3cdd049aba2771f7b6a98a2f0b4f4ccfb8f6a6b4ca398b43aab73898be"
+sha512 = "7d4125b30fdaae4087fa74ee896febf4e67b2a08abca39ac72c22c057139893187ee93c3aaaabce3554f2c92859defb57c15666ebf2bdbcd82e66b96e8151133"
+
+[blob]
+distfiles = [
+  "openwrt-24.10.5-sifiveu-generic-sifive_unmatched-ext4-sdcard.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "openwrt-24.10.5-sifiveu-generic-sifive_unmatched-ext4-sdcard.img"


### PR DESCRIPTION
## 自动更新

此 PR 由 Riko Bot 自动生成。

**包名:** openwrt-sifiveu
**类别:** board-image
**新版本:** 0.2410.5
**组合:** openwrt-sifive-unmatched

**更新的文件:**
- manifests/board-image/openwrt-sifive-unmatched/0.2410.5.toml

---
🤖 Generated by Riko Bot

## Summary by Sourcery

New Features:
- Introduce a board-image manifest for openwrt-sifive-unmatched version 24.10.5, including download sources, checksums, and provisioning metadata.