### PR TITLE
board-image/buildroot-sdk-sipeed-licheervnano: fix version 20260114

### DIFF
--- a/packages/board-image/buildroot-sdk-sipeed-licheervnano/0.20260114.0.toml
+++ b/packages/board-image/buildroot-sdk-sipeed-licheervnano/0.20260114.0.toml
@@ -8,8 +8,9 @@ upstream_version = "20260114"
 [[distfiles]]
 name = "2026-01-14-16-03-d4003f.tar.xz"
 size = 171913924
+strip_components = 0
 urls = [
-  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20260114/2026-01-14-16-03-d4003f.img.xz",
+  "https://github.com/sipeed/LicheeRV-Nano-Build/releases/download/20260114/2026-01-14-16-03-d4003f.tar.xz",
 ]
 restrict = ["mirror"]
 
@@ -26,4 +27,4 @@ distfiles = [
 strategy = "dd-v1"
 
 [provisionable.partition_map]
-disk = "2026-01-14-16-03-d4003f"
+disk = "2026-01-14-16-03-d4003f.img"


### PR DESCRIPTION
Fix 404 url.
And the PR check will fail, see issue https://github.com/ruyisdk/ruyi/issues/430