### PR TITLE
plugins: specify xthead quirk for milkv-duo profile

### DIFF
--- a/plugins/internal-riscv-profile-data/data/trivial-riscv64-profiles.toml
+++ b/plugins/internal-riscv-profile-data/data/trivial-riscv64-profiles.toml
@@ -26,4 +26,5 @@ mcpu = "thead-c910"
 
 [[profiles]]
 id = "milkv-duo"
+needed_quirks = ["xthead"]
 mcpu = "thead-c906"


### PR DESCRIPTION
Fix: #181

## Summary by Sourcery

Bug Fixes:
- Correct the milkv-duo profile configuration by declaring its dependency on the xthead quirk.