### PR TITLE
board-image/armbian-uefi-riscv64-minimal: add new packages

### DIFF
--- a/packages/board-image/armbian-uefi-riscv64-minimal/26.2.0-trunk.692.toml
+++ b/packages/board-image/armbian-uefi-riscv64-minimal/26.2.0-trunk.692.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian 26.2.0-trunk.692 image for UEFI RISC-V64 (minimal)"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.2.0-trunk.692"
+
+[[distfiles]]
+name = "Armbian_community_26.2.0-trunk.692_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz"
+size = 1041255172
+urls = [
+  "https://github.com/armbian/community/releases/download/26.2.0-trunk.692/Armbian_community_26.2.0-trunk.692_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "26d3b76973c47de1cca4fb3db7dcb010a22712d38552e90725fb3f5477c9b296"
+sha512 = "19efcf69ff2bb3a1ac6dca956e45292b968363cfc9b18eb7aa9543da97210816c5c8353920b358879af56ff3d1a3c825d9814abc6a57fe4f695d83fdba8ccecc"
+
+[blob]
+distfiles = [
+  "Armbian_community_26.2.0-trunk.692_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_community_26.2.0-trunk.692_Uefi-riscv64_trixie_current_6.18.21_minimal.img"

--- a/packages/board-image/armbian-uefi-riscv64-minimal/26.2.0-trunk.696.toml
+++ b/packages/board-image/armbian-uefi-riscv64-minimal/26.2.0-trunk.696.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian 26.2.0-trunk.696 image for UEFI RISC-V64 (minimal)"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.2.0-trunk.696"
+
+[[distfiles]]
+name = "Armbian_community_26.2.0-trunk.696_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz"
+size = 1049116684
+urls = [
+  "https://github.com/armbian/community/releases/download/26.2.0-trunk.696/Armbian_community_26.2.0-trunk.696_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b219230f5859f5fc131e4b3aabd2189f9bf82f50ae9d276d187f5ddb32c4f9fc"
+sha512 = "2a715e807f230e78d4e71172dd5466401599316e58a42542695a78c4c1272246df2bd8fb48547dcc08b8a94c043e0a79c6a88be7b16203c0f86d295d381ae6f8"
+
+[blob]
+distfiles = [
+  "Armbian_community_26.2.0-trunk.696_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_community_26.2.0-trunk.696_Uefi-riscv64_trixie_current_6.18.21_minimal.img"

--- a/packages/board-image/armbian-uefi-riscv64-minimal/26.2.0-trunk.703.toml
+++ b/packages/board-image/armbian-uefi-riscv64-minimal/26.2.0-trunk.703.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian 26.2.0-trunk.703 image for UEFI RISC-V64 (minimal)"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.2.0-trunk.703"
+
+[[distfiles]]
+name = "Armbian_community_26.2.0-trunk.703_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz"
+size = 1048263748
+urls = [
+  "https://github.com/armbian/community/releases/download/26.2.0-trunk.703/Armbian_community_26.2.0-trunk.703_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "0b154ba6279abc1468d6a963a4c9ee8e1ac606dec6e90a4a4acb339d87d3b85d"
+sha512 = "70ef738faa316655972eb3e55cafa6de4e4336a59d43e96b2de02f4c9913e01f6232233d3dbd3c25a3faf7e116718838847636caddee3925d507472aee07357c"
+
+[blob]
+distfiles = [
+  "Armbian_community_26.2.0-trunk.703_Uefi-riscv64_trixie_current_6.18.21_minimal.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_community_26.2.0-trunk.703_Uefi-riscv64_trixie_current_6.18.21_minimal.img"


### PR DESCRIPTION
Add armbian-uefi-riscv64-minimal manifest

## Summary by Sourcery

New Features:
- Introduce Armbian UEFI RISC-V64 minimal board-image manifests for upstream versions 26.2.0-trunk.692, 26.2.0-trunk.696, and 26.2.0-trunk.703.