### PR TITLE
docs(news): add RuyiSDK 0.48 release notes

### DIFF
--- a/news/2026-04-30-ruyi-0.48.en_US.md
+++ b/news/2026-04-30-ruyi-0.48.en_US.md
@@ -4,9 +4,47 @@ title: 'Release notes for RuyiSDK 0.48'
 
 # Release notes for RuyiSDK 0.48
 
+RuyiSDK 0.48 is now released. The corresponding package manager version is also 0.48.0.
+You can download the RuyiSDK package manager from one of the following locations:
+
+* [PyPI](https://pypi.org/project/ruyi/0.48.0/): `pip install ruyi`
+* <https://github.com/ruyisdk/ruyi/releases/tag/0.48.0>
+* <https://mirror.iscas.ac.cn/ruyisdk/ruyi/releases/0.48.0/>
+
+> [!NOTE]
+> RISC-V users can install `ruyi` using `pip`, but since some Python libraries
+> that `ruyi` depends on do not yet provide precompiled packages for the RISC-V
+> architecture on PyPI, the Python package manager will attempt to compile and
+> install these dependencies from source code when installing `ruyi`, which may
+> be very time-consuming or fail to compile.
+>
+> If you encounter problems installing `ruyi` on RISC-V devices, it is recommended
+> to use other installation methods.
+
+This update mainly consists of the following changes. Happy hacking!
+
 ## RuyiSDK Package Manager
 
+* Introduced the first build recipe workflow in the package manager:
+    * Added the `ruyi admin build-package` subcommand.
+    * Added the build recipe executor, marker loader, and related pluginhost APIs and load schemes for recipe execution.
+    * Added the initial `build-recipe-v1` capability gating for plugins.
+* Continued hardening the pluginhost so plugin code stays within a narrower, more portable subset:
+    * Added gating for language features such as decorators, type annotations, f-strings, generator expressions, `del`, matrix multiplication, chained comparisons, positional-only parameters, `while` loops, slice expressions, starred assignment targets, and the `is` / `is not` operators.
+    * Improved gate diagnostics and refreshed the pluginhost threat-model documentation.
+* Prepared a repository-format change for packagers by renaming the `manifests` directory to `packages`.
+* Added directory-based sysroot source options for virtual-environment creation.
+* Engineering iteration:
+    * Updated distribution images and dependency baselines, including the move to Ubuntu 24.04 LTS.
+    * Dropped Ubuntu 22.04 and Python 3.10 support.
+    * Refreshed dependency metadata and made CI image-builder home-directory handling more robust.
+
 ## RuyiSDK Software Repository
+
+* Improved device support:
+    * Milk-V Duo: specified the `xthead` quirk in the device profile. Thanks to [@weilinfox] for the contribution!
+
+[@weilinfox]: https://github.com/weilinfox
 
 ## IDE
 
@@ -20,9 +58,11 @@ title: 'Release notes for RuyiSDK 0.48'
 
 ### Eclipse
 
-* Refactor the logic of exception handling; clean redundant code lines; continue to optimize code style
-* Feature: "ruyi provision" environment has been built into the plugin.
+* Refactor the logic of exception handling; clean redundant code lines; continue to optimize code style.
+* Feature: the `ruyi provision` environment has been built into the plugin.
 * Feature: Package Explorer has been redesigned.
-* Feature: Virtual envs in open projects will be auto-detected.
+* Feature: virtual environments in open projects will be auto-detected.
 
-## Pre-release testing and known issues
+## Version Testing and Known Issues
+
+RuyiSDK 0.48.0 has passed [release testing](https://gitee.com/yunxiangluo/ruyisdk-test/blob/master/20260423/README.md). This version was tested based on the 0.48.0-beta.20260423 test version, and the 0.48.0 release is expected to be based on the 0.48.0-beta.20260423 codebase.

--- a/news/2026-04-30-ruyi-0.48.zh_CN.md
+++ b/news/2026-04-30-ruyi-0.48.zh_CN.md
@@ -4,9 +4,43 @@ title: 'RuyiSDK 0.48 版本更新说明'
 
 # RuyiSDK 0.48 版本更新说明
 
+RuyiSDK 0.48 现已发布，对应的包管理器版本也为 0.48.0。您可前往以下位置之一下载 RuyiSDK 包管理器：
+
+* [PyPI](https://pypi.org/project/ruyi/0.48.0/): `pip install ruyi`
+* <https://github.com/ruyisdk/ruyi/releases/tag/0.48.0>
+* <https://mirror.iscas.ac.cn/ruyisdk/ruyi/releases/0.48.0/>
+
+> [!NOTE]
+> RISC-V 用户可以使用 `pip` 安装 `ruyi`，但由于 `ruyi` 依赖的部分 Python
+> 库暂未在 PyPI 上提供 RISC-V 架构的预编译包，安装 `ruyi` 时 Python
+> 包管理器会尝试从源代码编译安装这些依赖，可能非常耗时或编译失败。
+>
+> 如果您在 RISC-V 设备上安装 `ruyi` 时遇到问题，建议使用其他安装方法。
+
+本次更新主要包含了以下内容，祝您使用愉快！
+
 ## RuyiSDK 包管理器
 
+* 在包管理器中引入了首个 build recipe 工作流：
+    * 新增 `ruyi admin build-package` 子命令。
+    * 新增 build recipe 执行器、标记文件加载器，以及配套的 pluginhost API 与专用 load scheme。
+    * 为插件新增首批 `build-recipe-v1` 能力门控。
+* 继续加固 pluginhost，使插件代码运行在更收敛、可移植性更好的语言子集之内：
+    * 新增对 decorators、类型注解、f-strings、生成器表达式、`del`、矩阵乘法运算符、链式比较、仅位置参数、`while` 循环、切片表达式、带星号的赋值目标，以及 `is` / `is not` 运算符等语言特性的门控。
+    * 改进了门控报错信息，并补充更新了 pluginhost 的威胁模型文档。
+* 为软件源格式调整做准备：将 `manifests` 目录重命名为 `packages`。
+* 为虚拟环境创建流程增加了基于目录的 sysroot 来源选项。
+* 工程化迭代：
+    * 更新发行镜像与依赖基线，其中包括迁移到 Ubuntu 24.04 LTS。
+    * 停止支持 Ubuntu 22.04 与 Python 3.10。
+    * 刷新依赖基线元数据，并增强 CI 镜像构建场景下用户主目录处理的健壮性。
+
 ## RuyiSDK 软件源
+
+* 完善了设备支持：
+    * 为 Milk-V Duo 的设备档案补充 `xthead` quirk。感谢 [@weilinfox] 的贡献！
+
+[@weilinfox]: https://github.com/weilinfox
 
 ## IDE
 
@@ -21,8 +55,10 @@ title: 'RuyiSDK 0.48 版本更新说明'
 ### Eclipse
 
 * 重构异常处理逻辑，清理冗余代码，继续优化代码风格。
-* 功能：支持启动 ruyi provision 环境烧写镜像。
+* 功能：支持启动 `ruyi provision` 环境烧写镜像。
 * 功能：包管理器页面已重新设计。
 * 功能：已打开项目中的虚拟环境将被自动探测到。
 
 ## 版本测试及遗留问题
+
+RuyiSDK 0.48.0 版本已通过[发版测试](https://gitee.com/yunxiangluo/ruyisdk-test/blob/master/20260423/README.md)。该版本测试是基于 0.48.0-beta.20260423 测试版本开展的，预期 0.48.0 版本将基于 0.48.0-beta.20260423 版本代码发版。


### PR DESCRIPTION
## Summary by Sourcery

Document the RuyiSDK 0.48.0 release with updated package manager information, key changes, and testing status in both English and Chinese release notes.

Documentation:
- Add download locations and installation notes for the RuyiSDK 0.48.0 package manager, including RISC-V-specific guidance.
- Describe new package manager capabilities, pluginhost hardening, repository layout updates, and engineering baseline changes for Ubuntu and Python support.
- Document improved device support for Milk-V Duo and recent Eclipse IDE enhancements, including built-in `ruyi provision` environment and virtual environment auto-detection.
- Record the 0.48.0 release testing status and its relationship to the 0.48.0-beta.20260423 build.