### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,34 +26,24 @@ jobs:
 
       - name: Install ruyi
         id: setup
+        uses: ruyisdk/setup-ruyi-action@v1
+        with:
+          ruyi-version: beta
+
+      - name: Configure ruyi
         run: |
-          mkdir bin/
+          ruyi config set repo.local "$(realpath ./packages-index)"
+          ruyi version
+          ruyi telemetry consent
 
-          version="$(curl --silent https://api.github.com/repos/ruyisdk/ruyi/releases/latest | \
-            jq --raw-output ".tag_name")"
-          curl -sL -o bin/ruyi "https://github.com/ruyisdk/ruyi/releases/download/${version}/ruyi-${version}.amd64"
-
-          chmod +x ./bin/ruyi
-          ./bin/ruyi config set repo.local "$(realpath ./packages-index)"
-          ./bin/ruyi version
-          ./bin/ruyi telemetry consent
-
-      - name: Test manifests
+      - name: Check formatting of board-image files
         run: |
-          for toml in `find ./packages-index/packages/board-image/ -type f`; do
-
-            echo test $toml
-            cp $toml test.toml
-
-            ./bin/ruyi admin format-manifest test.toml
-            diff -ura $toml test.toml
-
-          done
+          ruyi admin check --check format --repo ./packages-index --only-packages --category-is board-image
 
       - name: Test data structure
         run: |
-          ./bin/ruyi list --name-contains ""
+          ruyi admin check --check parse --repo ./packages-index
 
       - name: Post Install ruyi
         if: ${{ always() && steps.setup.conclusion == 'success' }}
-        run: ./bin/ruyi telemetry upload
+        run: ruyi telemetry upload

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Run dco-check
         uses: christophebedard/dco-check@0.5.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           args: '--verbose'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use the official ruyi setup action with new admin checks and bump the Python version used in DCO checks.

CI:
- Switch the format workflow to use the ruyisdk/setup-ruyi-action with a beta ruyi version and new admin check commands for manifest formatting and parsing.
- Update the DCO check workflow to run with Python 3.13 instead of 3.12.