### PR TITLE
source/opencv: add 4.13.0

### DIFF
--- a/packages/source/opencv/4.13.0.toml
+++ b/packages/source/opencv/4.13.0.toml
@@ -1,0 +1,19 @@
+format = "v1"
+
+[metadata]
+desc = "Open Source Computer Vision Library (upstream)"
+vendor = { name = "opencv", eula = "" }
+
+[[distfiles]]
+name = "opencv-4.13.0.tar.gz"
+size = 95420275
+urls = [
+  "https://github.com/opencv/opencv/archive/refs/tags/4.13.0.tar.gz",
+]
+
+[distfiles.checksums]
+sha256 = "1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d"
+sha512 = "ad677353cc1a4e51f2b9790724890eb65ec7633e0a658d63862767365b83d46e85791d691733e88c0f53d2b7294029c1b1ad8e5509c27d2edba8af7d63ade21e"
+
+[source]
+distfiles = ["opencv-4.13.0.tar.gz"]


### PR DESCRIPTION
Adds a manifest for OpenCV 4.13.0 (upstream stable, released 2025-12-31),
currently the latest release; packages-index only has 4.12.0.

Mirrors the existing source/opencv/4.12.0.toml, pointing at the upstream
GitHub archive tarball. Size and checksums verified locally against the
downloaded tarball:

  size:   95420275
  sha256: 1d40ca017ea51c533cf9fd5cbde5b5fe7ae248291ddf2af99d4c17cf8e13017d

## Summary by Sourcery

New Features:
- Introduce packaging support for OpenCV version 4.13.0 using the upstream GitHub archive tarball.