### PR TITLE
board-image/bianbu-{desktop,desktop-lite,minimal}-spacemit-k1{,-sd}: new version v2.3.3

### DIFF
--- a/packages/board-image/bianbu-desktop-lite-spacemit-k1-sd/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-lite-spacemit-k1-sd/2.3.3.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.3.3 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K1-sdcard-V2.3.3-20260128190347.img.zip"
+size = 2045271198
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-LXQt-K1-sdcard-V2.3.3-20260128190347.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7d4296336b2653b66da5c6ccd36debc6f49d2d5647b2f539cab2a00e3e35199c"
+sha512 = "a87f019198aeaf3a5536a83f74e0d35897ed42e668c7b50718f457331dd6837b7c7fa42fef5efc6fccdd44c2c12d1da9f603e50367b14198eee33857b37a3afd"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K1-sdcard-V2.3.3-20260128190347.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-LXQt-K1-sdcard-V2.3.3-20260128190347.img"

--- a/packages/board-image/bianbu-desktop-lite-spacemit-k1/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-lite-spacemit-k1/2.3.3.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.3.3 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K1-V2.3.3-20260128190347.zip"
+size = 2045266355
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-LXQt-K1-V2.3.3-20260128190347.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "aad80f7009924712842a65850ec72870b31170a1baedc75bc82e718ad97bbe83"
+sha512 = "a33117b6048714223e4f7c83e5a051659a84bb81c5c35bd11a6224eb4caaadec60cd6a595a96ca123d141630d493ad2f8e0d4f0cb6489a4e421defb1a4eb2049"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K1-V2.3.3-20260128190347.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/packages/board-image/bianbu-desktop-spacemit-k1-sd/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-spacemit-k1-sd/2.3.3.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.3.3 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-GNOME-K1-sdcard-V2.3.3-20260128191729.img.zip"
+size = 2641577330
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-GNOME-K1-sdcard-V2.3.3-20260128191729.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "62d71238029abee3c98f1c52a25dd117138aab6ee88e5b1ed609a17a985aeab1"
+sha512 = "fbf227c249175a7c08de5b088aec6922a6eb646ebba9ce267dee6eb22fb324f80c6a08d008d8b788dc55daec97db1c68776025d1ff7be304c823a02dc18451f1"
+
+[blob]
+distfiles = [
+  "Bianbu-GNOME-K1-sdcard-V2.3.3-20260128191729.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-GNOME-K1-sdcard-V2.3.3-20260128191729.img"

--- a/packages/board-image/bianbu-desktop-spacemit-k1/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-spacemit-k1/2.3.3.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop v2.3.3 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-GNOME-K1-V2.3.3-20260128191729.zip"
+size = 2641555399
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-GNOME-K1-V2.3.3-20260128191729.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "9873802695af5f6af906d7d1d69090e2a18b6ef014dd99fb41894c66b5202d68"
+sha512 = "24d898c6f49e983a397306dcd938b4375bcbee7292afe87805a8c571e8bf39a1f11cc07cdd36470554bcdc1d2e2e3db6bd5962594547d310f7fdbe57ce988ad6"
+
+[blob]
+distfiles = [
+  "Bianbu-GNOME-K1-V2.3.3-20260128191729.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/packages/board-image/bianbu-minimal-spacemit-k1-sd/2.3.3.toml
+++ b/packages/board-image/bianbu-minimal-spacemit-k1-sd/2.3.3.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.3.3 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-Minimal-K1-sdcard-V2.3.3-20260128183217.img.zip"
+size = 263673817
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-Minimal-K1-sdcard-V2.3.3-20260128183217.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "f8ef0caf7542f5afe5c5b63eaea4da00fbe475051256e2609679ec6cbf55c9b5"
+sha512 = "d577985fae1d2d7a3c9208771fb9b287fbceb3bfb315a44712c9bd8a90779cbad5aafebadf67d628bf70c4240875c489e33266ffa3349d23a456af4603582bd9"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-K1-sdcard-V2.3.3-20260128183217.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-Minimal-K1-sdcard-V2.3.3-20260128183217.img"

--- a/packages/board-image/bianbu-minimal-spacemit-k1/2.3.3.toml
+++ b/packages/board-image/bianbu-minimal-spacemit-k1/2.3.3.toml
@@ -1,0 +1,36 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v2.3.3 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-Minimal-K1-V2.3.3-20260128183217.zip"
+size = 263678114
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-Minimal-K1-V2.3.3-20260128183217.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "a43d4f9195bd04134effa51fd31ee0206d025b9bbb5d5af7b82af32cf8d80b2d"
+sha512 = "d5beedab6cc9e5dbcdeb1790fb5192f2e32f39ef679c1d7e884709da2479fb0e7df6da5fed3c8310810858192eeb025fd9d5bc9fbeb5300ed634c76e758d4014"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-K1-V2.3.3-20260128183217.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"


### PR DESCRIPTION
## Summary by Sourcery

Add board image definitions for Bianbu v2.3.3 on SpacemiT K1 across desktop, desktop-lite, and minimal variants, including SD card images.

New Features:
- Introduce Bianbu Desktop v2.3.3 board image for SpacemiT K1.
- Introduce Bianbu Desktop Lite v2.3.3 board image for SpacemiT K1.
- Introduce Bianbu Minimal v2.3.3 board image for SpacemiT K1.
- Add SD card image variants for Bianbu Desktop, Desktop Lite, and Minimal v2.3.3 on SpacemiT K1.