### PR TITLE
New device spacemit muse pi pro and uefi support for spacemit-k1-v1 strategy

### DIFF
--- a/entities/cpu/spacemit-m1.toml
+++ b/entities/cpu/spacemit-m1.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["uarch:spacemit-x60"]
+unique_among_type_during_traversal = true
+
+[cpu]
+id = "spacemit-m1"
+display_name = "SpacemiT Key Stone M1"

--- a/entities/device-variant/spacemit-musepipro@emmc.toml
+++ b/entities/device-variant/spacemit-musepipro@emmc.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:spacemit-m1"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "emmc"
+variant_name = "eMMC storage"

--- a/entities/device-variant/spacemit-musepipro@sd.toml
+++ b/entities/device-variant/spacemit-musepipro@sd.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:spacemit-m1"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "sd"
+variant_name = "SD/SSD storage"

--- a/entities/device/spacemit-musepipro.toml
+++ b/entities/device/spacemit-musepipro.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["device-variant:spacemit-musepipro@sd", "device-variant:spacemit-musepipro@emmc"]
+unique_among_type_during_traversal = true
+
+[device]
+id = "spacemit-musepipro"
+display_name = "SpacemiT MUSE Pi Pro"

--- a/entities/image-combo/bianbu-desktop-lite-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-desktop-lite-spacemit-k1-emmc.toml
@@ -2,6 +2,7 @@ ruyi-entity = "v0"
 
 related = [
   "device-variant:bananapi-bpi-f3@emmc",
+  "device-variant:spacemit-musepipro@emmc",
 ]
 unique_among_type_during_traversal = true
 

--- a/entities/image-combo/bianbu-desktop-lite-spacemit-k1-sd.toml
+++ b/entities/image-combo/bianbu-desktop-lite-spacemit-k1-sd.toml
@@ -2,6 +2,7 @@ ruyi-entity = "v0"
 
 related = [
   "device-variant:bananapi-bpi-f3@sd",
+  "device-variant:spacemit-musepipro@sd",
 ]
 unique_among_type_during_traversal = true
 

--- a/entities/image-combo/bianbu-desktop-lite-uefi-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-desktop-lite-uefi-spacemit-k1-emmc.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-musepipro@emmc",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop Lite UEFI for SpacemiT K1/M1"
+package_atoms = ["board-image/bianbu-desktop-lite-uefi-spacemit-k1"]

--- a/entities/image-combo/bianbu-desktop-lite-uefi-spacemit-k1-sd.toml
+++ b/entities/image-combo/bianbu-desktop-lite-uefi-spacemit-k1-sd.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-musepipro@sd",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop Lite UEFI for SpacemiT K1/M1"
+package_atoms = ["board-image/bianbu-desktop-lite-uefi-spacemit-k1-sd"]

--- a/entities/image-combo/bianbu-desktop-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-desktop-spacemit-k1-emmc.toml
@@ -2,6 +2,7 @@ ruyi-entity = "v0"
 
 related = [
   "device-variant:bananapi-bpi-f3@emmc",
+  "device-variant:spacemit-musepipro@emmc",
 ]
 unique_among_type_during_traversal = true
 

--- a/entities/image-combo/bianbu-desktop-spacemit-k1-sd.toml
+++ b/entities/image-combo/bianbu-desktop-spacemit-k1-sd.toml
@@ -2,6 +2,7 @@ ruyi-entity = "v0"
 
 related = [
   "device-variant:bananapi-bpi-f3@sd",
+  "device-variant:spacemit-musepipro@sd",
 ]
 unique_among_type_during_traversal = true
 

--- a/entities/image-combo/bianbu-minimal-spacemit-k1-emmc.toml
+++ b/entities/image-combo/bianbu-minimal-spacemit-k1-emmc.toml
@@ -2,6 +2,7 @@ ruyi-entity = "v0"
 
 related = [
   "device-variant:bananapi-bpi-f3@emmc",
+  "device-variant:spacemit-musepipro@emmc",
 ]
 unique_among_type_during_traversal = true
 

--- a/entities/image-combo/bianbu-minimal-spacemit-k1-sd.toml
+++ b/entities/image-combo/bianbu-minimal-spacemit-k1-sd.toml
@@ -2,6 +2,7 @@ ruyi-entity = "v0"
 
 related = [
   "device-variant:bananapi-bpi-f3@sd",
+  "device-variant:spacemit-musepipro@sd",
 ]
 unique_among_type_during_traversal = true
 

--- a/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1-sd/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1-sd/2.3.3.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.3.3 for SpacemiT K1, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K1-sdcard-V2.3.3-UEFI-20260407142626.img.zip"
+size = 2349061291
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-LXQt-K1-sdcard-V2.3.3-UEFI-20260407142626.img.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "36d3f0b44f3fb38d5fb9750b860a99f9a2d220daa06ed721ea811cf5f58513a3"
+sha512 = "3a04229bd29225028e003d182bd2c6a175ddbce551c0016359564ca613fb46b68b9a180d587097ef48bfe2d8d2e2c76ed7c32bd8739d8efe21e35e8a61616e0d"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K1-sdcard-V2.3.3-UEFI-20260407142626.img.zip",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-LXQt-K1-sdcard-V2.3.3-UEFI-20260407142626.img"

--- a/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1/2.3.3.toml
@@ -1,0 +1,39 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop Lite v2.3.3 for SpacemiT K1"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v2.3.3"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K1-V2.3.3-UEFI-20260407142626.zip"
+size = 2348792224
+urls = [
+  "https://archive.spacemit.com/image/k1/version/bianbu/v2.3.3/Bianbu-LXQt-K1-V2.3.3-UEFI-20260407142626.zip",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7a25b2960700a4d2b87cf1599fefae1c2759114d7e72c60307d53cb8c41989d9"
+sha512 = "c3a1249a6ecd35b96bbeb9ae2f72ca12456fc651c0c87ff529b58feff210de6a43cbb0bb5a754b3858c848934fd84f284f3addbb446b1f524d5abca458e75975"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K1-V2.3.3-UEFI-20260407142626.zip",
+]
+
+[provisionable]
+strategy = "spacemit-k1-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootfs_linux = "bootfs_linux.img"
+bootinfo = "factory/bootinfo_sd.bin"
+env = "env.bin"
+esp = "efi.img"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+rootfs_linux = "rootfs_linux.ext4"
+uboot = "u-boot.itb"

--- a/plugins/ruyi-device-provision-strategy-spacemit-k1/mod.star
+++ b/plugins/ruyi-device-provision-strategy-spacemit-k1/mod.star
@@ -30,7 +30,7 @@ def _pretend_spacemit_k1(img_paths, blkdev_paths):
 
     msg_load = _m("pretend-load-to-device")
     msg_flash = _m("pretend-flash-to-partition")
-    return [
+    ret = [
         msg_load.format(what="FSBL", img_path=fsbl_path),
         msg_load.format(what="U-Boot", img_path=uboot_path),
         msg_flash.format(img_path=gpt_path, part="gpt"),
@@ -39,9 +39,21 @@ def _pretend_spacemit_k1(img_paths, blkdev_paths):
         msg_flash.format(img_path=env_path, part="env"),
         msg_flash.format(img_path=opensbi_path, part="opensbi"),
         msg_flash.format(img_path=uboot_path, part="uboot"),
+    ]
+
+    if "esp" in img_paths:
+        ret.extend([
+            msg_flash.format(img_path=img_paths["esp"], part="ESP"),
+            msg_flash.format(img_path=img_paths["bootfs_linux"], part="bootfs_linux"),
+            msg_flash.format(img_path=img_paths["rootfs_linux"], part="rootfs_linux"),
+        ])
+
+    ret.extend([
         msg_flash.format(img_path=bootfs_path, part="bootfs"),
         msg_flash.format(img_path=rootfs_path, part="rootfs"),
-    ]
+    ])
+
+    return ret
 
 
 #def _flash_spacemit_k1(img_paths: PartitionMapDecl, _: PartitionMapDecl) -> int:
@@ -61,6 +73,13 @@ def _flash_spacemit_k1(img_paths, blkdev_paths):
     # sudo fastboot flash env env.bin
     # sudo fastboot flash opensbi fw_dynamic.itb
     # sudo fastboot flash uboot u-boot.itb
+    #
+    # # For UEFI image, also
+    # # See https://github.com/ruyisdk/packages-index/issues/197
+    # sudo fastboot flash ESP efi.img
+    # sudo fastboot flash bootfs_linux bootfs_linux.img
+    # sudo fastboot flash rootfs_linux rootfs_linux.ext4
+    #
     # sudo fastboot flash bootfs bootfs.ext4
     # sudo fastboot flash rootfs rootfs.ext4
     #
@@ -112,9 +131,19 @@ def _flash_spacemit_k1(img_paths, blkdev_paths):
         "env": img_paths["env"],
         "opensbi": img_paths["opensbi"],
         "uboot": img_paths["uboot"],
+    }
+
+    if "esp" in img_paths:
+        partitions.update({
+            "ESP": img_paths["esp"],
+            "bootfs_linux": img_paths["bootfs_linux"],
+            "rootfs_linux": img_paths["rootfs_linux"],
+        })
+
+    partitions.update({
         "bootfs": img_paths["bootfs"],
         "rootfs": img_paths["rootfs"],
-    }
+    })
 
     for partition, img_path in partitions.items():
         RUYI.log.I(_m("flashing-partition").format(part=partition))


### PR DESCRIPTION
Fix: #197

## Summary by Sourcery

Add UEFI-capable Bianbu Desktop Lite images and SpacemiT MUSE Pi Pro device definitions, and extend the SpacemiT K1 provisioning strategy to handle optional UEFI partitions.

New Features:
- Introduce UEFI Bianbu Desktop Lite eMMC image package for SpacemiT K1/M1 boards.
- Introduce UEFI Bianbu Desktop Lite SD image package for SpacemiT K1/M1 boards.
- Add SpacemiT MUSE Pi Pro device, variants (eMMC and SD), and SpacemiT M1 CPU entities.
- Add image-combo entities linking MUSE Pi Pro variants to the new UEFI images.

Enhancements:
- Extend the spacemit-k1 provisioning strategy to optionally flash UEFI-specific partitions (ESP, bootfs_linux, rootfs_linux) when present in the image.