### PR TITLE
New device Spacemit K3 Pico-ITX

### DIFF
--- a/entities/cpu/spacemit-k3.toml
+++ b/entities/cpu/spacemit-k3.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["uarch:spacemit-x100"]
+unique_among_type_during_traversal = true
+
+[cpu]
+id = "spacemit-k3"
+display_name = "SpacemiT Key Stone K3"

--- a/entities/device-variant/spacemit-k3-pico-itx@sd.toml
+++ b/entities/device-variant/spacemit-k3-pico-itx@sd.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:spacemit-k3"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "sd"
+variant_name = "SD/SSD storage"

--- a/entities/device-variant/spacemit-k3-pico-itx@ufs.toml
+++ b/entities/device-variant/spacemit-k3-pico-itx@ufs.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["cpu:spacemit-k3"]
+unique_among_type_during_traversal = true
+
+[device-variant]
+id = "ufs"
+variant_name = "UFS storage"

--- a/entities/device/spacemit-k3-pico-itx.toml
+++ b/entities/device/spacemit-k3-pico-itx.toml
@@ -1,0 +1,8 @@
+ruyi-entity = "v0"
+
+related = ["device-variant:spacemit-k3-pico-itx@sd", "device-variant:spacemit-k3-pico-itx@ufs"]
+unique_among_type_during_traversal = true
+
+[device]
+id = "spacemit-k3-pico-itx"
+display_name = "SpacemiT K3 Pico-ITX"

--- a/entities/image-combo/bianbu-desktop-lxqt-spacemit-k3-sd.toml
+++ b/entities/image-combo/bianbu-desktop-lxqt-spacemit-k3-sd.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-k3-pico-itx@sd",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop LXQt for SpacemiT K3"
+package_atoms = ["board-image/bianbu-desktop-lxqt-spacemit-k3-sd"]

--- a/entities/image-combo/bianbu-desktop-lxqt-spacemit-k3-ufs.toml
+++ b/entities/image-combo/bianbu-desktop-lxqt-spacemit-k3-ufs.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-k3-pico-itx@ufs",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop LXQt for SpacemiT K3"
+package_atoms = ["board-image/bianbu-desktop-lxqt-spacemit-k3"]

--- a/entities/image-combo/bianbu-desktop-lxqt-uefi-spacemit-k3-ufs.toml
+++ b/entities/image-combo/bianbu-desktop-lxqt-uefi-spacemit-k3-ufs.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-k3-pico-itx@ufs",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Desktop LXQt UEFI for SpacemiT K3"
+package_atoms = ["board-image/bianbu-desktop-lxqt-uefi-spacemit-k3"]

--- a/entities/image-combo/bianbu-minimal-spacemit-k3-sd.toml
+++ b/entities/image-combo/bianbu-minimal-spacemit-k3-sd.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-k3-pico-itx@sd",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Minimal for SpacemiT K3"
+package_atoms = ["board-image/bianbu-minimal-spacemit-k3-sd"]

--- a/entities/image-combo/bianbu-minimal-spacemit-k3-ufs.toml
+++ b/entities/image-combo/bianbu-minimal-spacemit-k3-ufs.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-k3-pico-itx@ufs",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Minimal for SpacemiT K3"
+package_atoms = ["board-image/bianbu-minimal-spacemit-k3"]

--- a/entities/image-combo/bianbu-minimal-uefi-spacemit-k3-ufs.toml
+++ b/entities/image-combo/bianbu-minimal-uefi-spacemit-k3-ufs.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-k3-pico-itx@ufs",
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Bianbu Minimal UEFI for SpacemiT K3"
+package_atoms = ["board-image/bianbu-minimal-uefi-spacemit-k3"]

--- a/entities/uarch/spacemit-x100.toml
+++ b/entities/uarch/spacemit-x100.toml
@@ -1,0 +1,14 @@
+ruyi-entity = "v0"
+
+related = ["arch:riscv64"]
+unique_among_type_during_traversal = true
+
+[uarch]
+id = "spacemit-x100"
+display_name = "SpacemiT X100"
+arch = "riscv64"
+
+[uarch.riscv]
+# See: https://www.spacemit.com/community/document/info?lang=zh&nodepath=hardware/key_stone/k3/k3_docs/k3_ds.md
+#      https://github.com/ruyisdk/packages-index/issues/200
+isa = "rv64imafdcvh_sdtrig_smaia_smcntrpmf_smepmp_smstateen_ssaia_sscofpmf_sspm_sstc_svinval_svnapot_svpbmt_svvptc_zicbom_zicbop_zicboz_zicntr_zicond_zicsr_zifencei_zihintntl_zihintpause_zihpm_zimop_zaamo_zalrsc_zawrs_zca_zcb_zcd_zcmop_zfa_zfbfmin_zfh_zfhmin_zkt_zba_zbb_zbc_zbs_zbkc_zmmul_zvbb_zvbc_zve32f_zve32x_zve64d_zve64f_zve64x_zvfbfmin_zvfbfwma_zvfh_zvfhmin_zvkb_zvkg_zvkned_zvknha_zvknhb_zvksed_zvksh_zvkt_zvl32b_zvl64b_zvl128b_zvl256b_xsmtvmadoti8

--- a/messages.toml
+++ b/messages.toml
@@ -571,3 +571,13 @@ zh_CN = "正在烧写 [yellow]{part}[/] 分区"
 ["plugins/ruyi-device-provision-strategy-spacemit-k1/flashing-partition-failed"]
 en_US = "failed to flash the [yellow]{part}[/] partition"
 zh_CN = "烧写 [yellow]{part}[/] 分区失败"
+
+# ruyi-device-provision-strategy-spacemit-k3
+
+["plugins/ruyi-device-provision-strategy-spacemit-k3/oem-super-speed"]
+en_US = "set USB link to super speed mode"
+zh_CN = "配置 USB 连接到高速模式"
+
+["plugins/ruyi-device-provision-strategy-spacemit-k3/oem-speed-failed"]
+en_US = "failed to set USB link to super speed mode"
+zh_CN = "配置高速模式失败"

--- a/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1-sd/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1-sd/2.3.3.toml
@@ -1,7 +1,7 @@
 format = "v1"
 
 [metadata]
-desc = "Official Bianbu Desktop Lite v2.3.3 for SpacemiT K1, SD image"
+desc = "Official Bianbu Desktop Lite UEFI v2.3.3 for SpacemiT K1, SD image"
 vendor = { name = "SpacemiT", eula = "" }
 upstream_version = "v2.3.3"
 

--- a/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1/2.3.3.toml
+++ b/packages/board-image/bianbu-desktop-lite-uefi-spacemit-k1/2.3.3.toml
@@ -1,7 +1,7 @@
 format = "v1"
 
 [metadata]
-desc = "Official Bianbu Desktop Lite v2.3.3 for SpacemiT K1"
+desc = "Official Bianbu Desktop Lite UEFI v2.3.3 for SpacemiT K1"
 vendor = { name = "SpacemiT", eula = "" }
 upstream_version = "v2.3.3"
 

--- a/packages/board-image/bianbu-desktop-lxqt-spacemit-k3-sd/4.0.0.toml
+++ b/packages/board-image/bianbu-desktop-lxqt-spacemit-k3-sd/4.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop LXQt v4.0 for SpacemiT K3, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K3-sdcard-v4.0-20260430170328.img.gz"
+size = 2333135162
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0/Bianbu-LXQt-K3-sdcard-v4.0-20260430170328.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d741291c9aa0c67297d13815a5e505b2d471cf78bb6432d55822b32258fe5930"
+sha512 = "ae1185a4fcaa60a3407caa3e337832a2f9549879e2fa86426c7ea55729c0a02227d06fc81ed6febc2d1f53e6aea6f46f48533a7b604b2822a92a9fe3121ec180"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K3-sdcard-v4.0-20260430170328.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-LXQt-K3-sdcard-v4.0-20260430170328.img"

--- a/packages/board-image/bianbu-desktop-lxqt-spacemit-k3-sd/4.0.1.toml
+++ b/packages/board-image/bianbu-desktop-lxqt-spacemit-k3-sd/4.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop LXQt v4.0.1 for SpacemiT K3, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0.1"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K3-sdcard-v4.0.1-20260521185240.img.gz"
+size = 2314127308
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0.1/Bianbu-LXQt-K3-sdcard-v4.0.1-20260521185240.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "e048151a6b6ccaf0b68fdef96b58546a4b0b6fe4330a39b600af98c0840da471"
+sha512 = "5646e5af9bcf0ed5932ef0100019721ea44d30fde41b1fd8f24ccf63bbe3b672ac46857a9dd29d325816f97a5e74a8a5ef970c1c79ef044c54b880db70b1002f"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K3-sdcard-v4.0.1-20260521185240.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-LXQt-K3-sdcard-v4.0.1-20260521185240.img"

--- a/packages/board-image/bianbu-desktop-lxqt-spacemit-k3/4.0.0.toml
+++ b/packages/board-image/bianbu-desktop-lxqt-spacemit-k3/4.0.0.toml
@@ -1,0 +1,38 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop LXQt v4.0 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K3-v4.0-20260430170328.tar.gz"
+size = 2333137667
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0/Bianbu-LXQt-K3-v4.0-20260430170328.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1b379fc648b1503b30fd317351c0b8da30c986f1090cf28080bbd5bfa4d95f73"
+sha512 = "ace1206f0d2c11ca636d054a58fdb67e1807855253c1308f0bab87d889298a9e2b56a3d0f3b5ed739870f955a756461aed00634ea188dc66d4a6578b9e86772f"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K3-v4.0-20260430170328.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/packages/board-image/bianbu-desktop-lxqt-spacemit-k3/4.0.1.toml
+++ b/packages/board-image/bianbu-desktop-lxqt-spacemit-k3/4.0.1.toml
@@ -1,0 +1,38 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop LXQt v4.0.1 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0.1"
+
+[[distfiles]]
+name = "Bianbu-LXQt-K3-v4.0.1-20260521185240.tar.gz"
+size = 2314313160
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0.1/Bianbu-LXQt-K3-v4.0.1-20260521185240.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "b9a204272c4c9458f4c8d1606598d7e40731991f8523d4b63378bfcac1ced54a"
+sha512 = "7fe274c0b671ff3042998c8e230ef89cfce650d16524ad54163a378cb38cc47c40c70ece1bb5b1dbca951c4fcb3eafee66a61716dee36c0203e2b5d28d5bca08"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-K3-v4.0.1-20260521185240.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/packages/board-image/bianbu-desktop-lxqt-uefi-spacemit-k3/4.0.0.toml
+++ b/packages/board-image/bianbu-desktop-lxqt-uefi-spacemit-k3/4.0.0.toml
@@ -1,0 +1,41 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop LXQt UEFI v4.0 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0"
+
+[[distfiles]]
+name = "Bianbu-LXQt-UEFI-K3-v4.0-20260430171239.tar.gz"
+size = 2347568292
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0/Bianbu-LXQt-UEFI-K3-v4.0-20260430171239.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "f07b37ce66f8ea935d4cab73a0b36020626080fe152a7f4ec66369e28c020b81"
+sha512 = "e47893a50984159a10d139bc51227c16748fffb897f3c7214e40ad3cb5b8b3a7141d68bd2614b93400bd2a20cf538c05c9adce55b2ebde8259fc10b1f60004a5"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-UEFI-K3-v4.0-20260430171239.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+bootinfo_mtd = "factory/bootinfo_spinor.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+mtd = "partition_4M.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "edk2.itb"
+uboot_stage = "u-boot.itb"

--- a/packages/board-image/bianbu-desktop-lxqt-uefi-spacemit-k3/4.0.1.toml
+++ b/packages/board-image/bianbu-desktop-lxqt-uefi-spacemit-k3/4.0.1.toml
@@ -1,0 +1,41 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Desktop LXQt UEFI v4.0.1 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0.1"
+
+[[distfiles]]
+name = "Bianbu-LXQt-UEFI-K3-v4.0.1-20260521185157.tar.gz"
+size = 2326887925
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0.1/Bianbu-LXQt-UEFI-K3-v4.0.1-20260521185157.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "a81632869d87d9da243fd9c96641b5ba375e9911bc260caa08195f25fcb3ec33"
+sha512 = "56c360feecfb2c09cd8b5f2d95c9c2821eed308c267d19f811b6a59113f6828aeed69b1e52ab92963748e423e9df842a9180cb44c0bc16e269d8181b542b4bcc"
+
+[blob]
+distfiles = [
+  "Bianbu-LXQt-UEFI-K3-v4.0.1-20260521185157.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+bootinfo_mtd = "factory/bootinfo_spinor.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+mtd = "partition_4M.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "edk2.itb"
+uboot_stage = "u-boot.itb"

--- a/packages/board-image/bianbu-minimal-spacemit-k3-sd/4.0.0.toml
+++ b/packages/board-image/bianbu-minimal-spacemit-k3-sd/4.0.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v4.0 for SpacemiT K3, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0"
+
+[[distfiles]]
+name = "Bianbu-Minimal-K3-sdcard-v4.0-20260430165016.img.gz"
+size = 402676887
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0/Bianbu-Minimal-K3-sdcard-v4.0-20260430165016.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "0666426ea218b875eb13bcb301d9fbacd3cf7811b35510cfd8ce9008d4ee03cf"
+sha512 = "488387c463544be2812f893b54fdff19eabcc6c78aaea085cb38d709ba17f55175532f1e1dfafed7f2d051a1e20290a3cf80b418b9f301d0d601f751912f4ee6"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-K3-sdcard-v4.0-20260430165016.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-Minimal-K3-sdcard-v4.0-20260430165016.img"

--- a/packages/board-image/bianbu-minimal-spacemit-k3-sd/4.0.1.toml
+++ b/packages/board-image/bianbu-minimal-spacemit-k3-sd/4.0.1.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v4.0.1 for SpacemiT K3, SD image"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0.1"
+
+[[distfiles]]
+name = "Bianbu-Minimal-K3-sdcard-v4.0.1-20260521183730.img.gz"
+size = 386831751
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0.1/Bianbu-Minimal-K3-sdcard-v4.0.1-20260521183730.img.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d4f0512945c6201ef0040d864ef083c0cef1711dd9dc34e63e4a8f4d9e45aba3"
+sha512 = "53e7c17b6dea3fb1738052c18cbf08d5ebb8b4adc0a164fc183fa03239abd20bffd049e84ace1720b00ce9c397748ca8b0309e751406c205ff005fa487ffc812"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-K3-sdcard-v4.0.1-20260521183730.img.gz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Bianbu-Minimal-K3-sdcard-v4.0.1-20260521183730.img"

--- a/packages/board-image/bianbu-minimal-spacemit-k3/4.0.0.toml
+++ b/packages/board-image/bianbu-minimal-spacemit-k3/4.0.0.toml
@@ -1,0 +1,38 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v4.0 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0"
+
+[[distfiles]]
+name = "Bianbu-Minimal-K3-v4.0-20260430165016.tar.gz"
+size = 402693456
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0/Bianbu-Minimal-K3-v4.0-20260430165016.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "d782ce25d50d06ef70c1c47eb6ef48bb132211998a7c0cc38a08c4c8c0bd5801"
+sha512 = "553dff261eeabe88a2d0a84649e63e3337c12d4af388783635b9aa993de6f4705b73b446eaffd8634a40c75d478a156a84950b44c5dbb84fcb7ee7febbc6ab51"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-K3-v4.0-20260430165016.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/packages/board-image/bianbu-minimal-spacemit-k3/4.0.1.toml
+++ b/packages/board-image/bianbu-minimal-spacemit-k3/4.0.1.toml
@@ -1,0 +1,38 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal v4.0.1 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0.1"
+
+[[distfiles]]
+name = "Bianbu-Minimal-K3-v4.0.1-20260521183730.tar.gz"
+size = 386934093
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0.1/Bianbu-Minimal-K3-v4.0.1-20260521183730.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1584b1607c564104e4dcfd0253e5c86cf80d8d6a59b2b20fa61f4550fcb656d1"
+sha512 = "29e6879098ef82b38b1eb2a5135ebd2c2e53a74a2291f5b90dc3878eb893e4659514e0351c21625da647daa19f0eb6e18cab77a26f8346043b2322c42857d7ce"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-K3-v4.0.1-20260521183730.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "u-boot.itb"

--- a/packages/board-image/bianbu-minimal-uefi-spacemit-k3/4.0.0.toml
+++ b/packages/board-image/bianbu-minimal-uefi-spacemit-k3/4.0.0.toml
@@ -1,0 +1,41 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal UEFI v4.0 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0"
+
+[[distfiles]]
+name = "Bianbu-Minimal-UEFI-K3-v4.0-20260430165035.tar.gz"
+size = 444331750
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0/Bianbu-Minimal-UEFI-K3-v4.0-20260430165035.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "6528a54fa83601b3459bd7aeb2f3143a2ea3d9e62faade3283dbaa03566544f6"
+sha512 = "c8f195f7db8884bc16dda25899cabbac5e8051eaabc6817d4f82feeefb829dbf7d577838150e8a7ebbc5e0cc4051e4c21224f045c1759987605c5ccad60957db"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-UEFI-K3-v4.0-20260430165035.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+bootinfo_mtd = "factory/bootinfo_spinor.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+mtd = "partition_4M.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "edk2.itb"
+uboot_stage = "u-boot.itb"

--- a/packages/board-image/bianbu-minimal-uefi-spacemit-k3/4.0.1.toml
+++ b/packages/board-image/bianbu-minimal-uefi-spacemit-k3/4.0.1.toml
@@ -1,0 +1,41 @@
+format = "v1"
+
+[metadata]
+desc = "Official Bianbu Minimal UEFI v4.0.1 for SpacemiT K3"
+vendor = { name = "SpacemiT", eula = "" }
+upstream_version = "v4.0.1"
+
+[[distfiles]]
+name = "Bianbu-Minimal-UEFI-K3-v4.0.1-20260521183844.tar.gz"
+size = 427537964
+urls = [
+  "https://archive.spacemit.com/image/k3/version/bianbu/v4.0.1/Bianbu-Minimal-UEFI-K3-v4.0.1-20260521183844.tar.gz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "2bf9207c7d2116bf784e9ff14dc4b692104767caf2b6241a3c6279d749a8e714"
+sha512 = "ea2b2ec441096aeb11fdaac4a9c2eac1e02a47dc9b324e401f15cc18ae00ef497f191d154ed3a534455f07fc1889e00b616c8d171fbbd02ec2ee3e24a6d5fb22"
+
+[blob]
+distfiles = [
+  "Bianbu-Minimal-UEFI-K3-v4.0.1-20260521183844.tar.gz",
+]
+
+[provisionable]
+strategy = "spacemit-k3-v1"
+
+[provisionable.partition_map]
+bootfs = "bootfs.ext4"
+bootinfo = "factory/bootinfo_block.bin"
+bootinfo_mtd = "factory/bootinfo_spinor.bin"
+env = "env.bin"
+esos = "esos.itb"
+esp = "esp.vfat"
+fsbl = "factory/FSBL.bin"
+gpt = "partition_universal.json"
+mtd = "partition_4M.json"
+opensbi = "fw_dynamic.itb"
+rootfs = "rootfs.ext4"
+uboot = "edk2.itb"
+uboot_stage = "u-boot.itb"

--- a/plugins/internal-i18n-compat/data/messages.toml
+++ b/plugins/internal-i18n-compat/data/messages.toml
@@ -146,3 +146,13 @@ zh_CN = "正在烧写 [yellow]{part}[/] 分区"
 ["plugins/ruyi-device-provision-strategy-spacemit-k1/flashing-partition-failed"]
 en_US = "failed to flash the [yellow]{part}[/] partition"
 zh_CN = "烧写 [yellow]{part}[/] 分区失败"
+
+# ruyi-device-provision-strategy-spacemit-k3
+
+["plugins/ruyi-device-provision-strategy-spacemit-k3/oem-super-speed"]
+en_US = "set USB link to super speed mode"
+zh_CN = "配置 USB 连接到高速模式"
+
+["plugins/ruyi-device-provision-strategy-spacemit-k3/oem-speed-failed"]
+en_US = "failed to set USB link to super speed mode"
+zh_CN = "配置高速模式失败"

--- a/plugins/ruyi-device-provision-strategy-spacemit-k3-v1
+++ b/plugins/ruyi-device-provision-strategy-spacemit-k3-v1
@@ -1,0 +1,1 @@
+ruyi-device-provision-strategy-spacemit-k3

--- a/plugins/ruyi-device-provision-strategy-spacemit-k3/mod.star
+++ b/plugins/ruyi-device-provision-strategy-spacemit-k3/mod.star
@@ -1,0 +1,208 @@
+RUYI = ruyi_plugin_rev(1)
+
+load(
+    "ruyi-plugin://internal-device-provisioner-common",
+    _do_fastboot="do_fastboot",
+    _do_fastboot_flash="do_fastboot_flash",
+    _need_host_blkdevs_none="need_host_blkdevs_none",
+)
+
+load(
+    "ruyi-plugin://internal-i18n-compat",
+    _msg="msg",
+)
+
+
+def _m(msgid):
+    ret = _msg("plugins/ruyi-device-provision-strategy-spacemit-k1/" + msgid)
+    if not ret:
+        ret = _msg("plugins/ruyi-device-provision-strategy-spacemit-k3/" + msgid)
+
+    return ret
+
+
+#def _pretend_spacemit_k3(img_paths: PartitionMapDecl, _: PartitionMapDecl) -> list[str]:
+def _pretend_spacemit_k3(img_paths, blkdev_paths):
+    fsbl_path = img_paths["fsbl"]
+    uboot_path = img_paths["uboot"]
+    gpt_path = img_paths["gpt"]
+    bootinfo_path = img_paths["bootinfo"]
+    env_path = img_paths["env"]
+    esos_path = img_paths["esos"]
+    esp_path = img_paths["esp"]
+    opensbi_path = img_paths["opensbi"]
+    bootfs_path = img_paths["bootfs"]
+    rootfs_path = img_paths["rootfs"]
+
+    uboot_stage_path = uboot_path
+    if "uboot_stage" in img_paths:
+        uboot_stage_path = img_paths["uboot_stage"]
+
+    msg_load = _m("pretend-load-to-device")
+    msg_flash = _m("pretend-flash-to-partition")
+    ret = [
+        msg_load.format(what="FSBL", img_path=fsbl_path),
+        msg_load.format(what="U-Boot", img_path=uboot_stage_path),
+    ]
+
+    if "mtd" in img_paths:
+        ret.extend([
+            msg_flash.format(img_path=img_paths["mtd"], part="mtd"),
+            msg_flash.format(img_path=img_paths["bootinfo_mtd"], part="bootinfo"),
+
+            msg_flash.format(img_path=fsbl_path, part="fsbl"),
+            msg_flash.format(img_path=env_path, part="env"),
+            msg_flash.format(img_path=esos_path, part="esos"),
+            msg_flash.format(img_path=opensbi_path, part="opensbi"),
+            msg_flash.format(img_path=uboot_path, part="uboot"),
+        ])
+
+    ret.extend([
+        msg_flash.format(img_path=gpt_path, part="gpt"),
+        msg_flash.format(img_path=env_path, part="env"),
+        msg_flash.format(img_path=bootinfo_path, part="bootinfo"),
+        msg_flash.format(img_path=fsbl_path, part="fsbl"),
+        msg_flash.format(img_path=img_paths["esos"], part="esos"),
+        msg_flash.format(img_path=opensbi_path, part="opensbi"),
+        msg_flash.format(img_path=uboot_path, part="uboot"),
+        msg_flash.format(img_path=esp_path, part="ESP"),
+        msg_flash.format(img_path=bootfs_path, part="bootfs"),
+        msg_flash.format(img_path=rootfs_path, part="rootfs"),
+    ])
+
+    return ret
+
+
+#def _flash_spacemit_k3(img_paths: PartitionMapDecl, _: PartitionMapDecl) -> int:
+def _flash_spacemit_k3(img_paths, blkdev_paths):
+    # Perform the equivalent of the following commands:
+    #
+    # sudo fastboot stage factory/FSBL.bin
+    # sudo fastboot continue
+    # # Wait for 1 sec
+    # fastboot oem speed:super-speed
+    # sudo fastboot stage u-boot.itb
+    # sudo fastboot continue
+    # # Wait for 1 sec
+    #
+    # # UEFI also
+    # sudo fastboot flash mtd partition_4M.json
+    # sudo fastboot flash bootinfo factory/bootinfo_spinor.bin
+    # sudo fastboot flash fsbl factory/FSBL.bin
+    # sudo fastboot flash env env.bin
+    # sudo fastboot flash esos esos.itb
+    # sudo fastboot flash opensbi fw_dynamic.itb
+    # sudo fastboot flash uboot u-boot.itb/edk2.itb
+    #
+    # sudo fastboot flash gpt partition_universal.json
+    # sudo fastboot flash env env.bin
+    # sudo fastboot flash bootinfo factory/bootinfo_block.bin
+    # sudo fastboot flash fsbl factory/FSBL.bin
+    # sudo fastboot flash esos esos.itb
+    # sudo fastboot flash opensbi fw_dynamic.itb
+    # sudo fastboot flash uboot u-boot.itb/edk2.itb
+    # sudo fastboot flash ESP esp.vfat
+    # sudo fastboot flash bootfs bootfs.ext4
+    # sudo fastboot flash rootfs rootfs.ext4
+    #
+    # See https://github.com/ruyisdk/packages-index/issues/200
+
+    wait_secs = 1.0
+    fsbl_img_path = img_paths["fsbl"]
+    uboot_img_path = img_paths["uboot"]
+    if "uboot_stage" in img_paths:
+        uboot_img_path = img_paths["uboot_stage"]
+
+    # Stage FSBL and continue
+    RUYI.log.I(_m("staging-fsbl"))
+    ret = _do_fastboot("stage", fsbl_img_path)
+    if ret != 0:
+        RUYI.log.F(_m("staging-fsbl-failed"))
+        return ret
+
+    RUYI.log.I(_m("continuing-to-fsbl"))
+    ret = _do_fastboot("continue")
+    if ret != 0:
+        RUYI.log.F(_m("continuing-to-fsbl-failed"))
+        return ret
+
+    # Wait for 1 second
+    RUYI.log.I(_m("wait-fsbl").format(wait_secs=wait_secs))
+    RUYI.sleep(wait_secs)
+
+    # # Do fastboot oem speed:super-speed
+    # RUYI.log.I(_m("oem-super-speed"))
+    # ret = _do_fastboot("oem", "speed:super-speed")
+    # if ret != 0:
+    #     RUYI.log.F(_m("oem-speed-failed"))
+
+    # Stage u-boot and continue
+    RUYI.log.I(_m("staging-uboot"))
+    ret = _do_fastboot("stage", uboot_img_path)
+    if ret != 0:
+        RUYI.log.F(_m("staging-uboot-failed"))
+        return ret
+
+    RUYI.log.I(_m("continuing-to-uboot"))
+    ret = _do_fastboot("continue")
+    if ret != 0:
+        RUYI.log.F(_m("continuing-to-uboot-failed"))
+        return ret
+        
+    # Wait for 1 second
+    RUYI.log.I(_m("wait-uboot").format(wait_secs=wait_secs))
+    RUYI.sleep(wait_secs)
+
+    # Flash all partitions
+    partitions = []
+
+    if "mtd" in img_paths:
+        partitions.extend([
+            ("mtd", img_paths["mtd"]),
+            ("bootinfo", img_paths["bootinfo_mtd"]),
+
+            ("fsbl", img_paths["fsbl"]),
+            ("env", img_paths["env"]),
+            ("esos", img_paths["esos"]),
+            ("opensbi", img_paths["opensbi"]),
+            ("uboot", img_paths["uboot"]),
+        ])
+
+    partitions.extend([
+        ("gpt", img_paths["gpt"]),
+        ("env", img_paths["env"]),
+        ("bootinfo", img_paths["bootinfo"]),
+        ("fsbl", img_paths["fsbl"]),
+        ("esos", img_paths["esos"]),
+        ("opensbi", img_paths["opensbi"]),
+        ("uboot", img_paths["uboot"]),
+        ("ESP", img_paths["esp"]),
+        ("bootfs", img_paths["bootfs"]),
+        ("rootfs", img_paths["rootfs"]),
+    ])
+
+    for partition, img_path in partitions:
+        RUYI.log.I(_m("flashing-partition").format(part=partition))
+        ret = _do_fastboot_flash(partition, img_path)
+        if ret != 0:
+            RUYI.log.F(_m("flashing-partition-failed").format(part=partition))
+            return ret
+
+    return 0
+
+
+#
+# Device Provisioning Strategy Plugin Interface
+#
+
+_spacemit_k3_v1 = {
+    "priority": 10,
+    "need_host_blkdevs_fn": _need_host_blkdevs_none,
+    "need_cmd": ["sudo", "fastboot"],
+    "pretend_fn": _pretend_spacemit_k3,
+    "flash_fn": _flash_spacemit_k3,
+}
+
+PROVIDED_DEVICE_PROVISION_STRATEGIES_V1 = {
+    "spacemit-k3-v1": _spacemit_k3_v1,
+}


### PR DESCRIPTION
Fix: #200

``entities/uarch/spacemit-x100.toml`` 这个我也无法完全确定。在 #200 附上了 ruapu 的结果和 cpuinfo。
## Summary by Sourcery

Add support for the SpacemiT K3 Pico-ITX device based on the SpacemiT X100 RISC-V microarchitecture, including its CPU and storage variants.

New Features:
- Introduce SpacemiT X100 RISC-V microarchitecture entity with detailed ISA definition.
- Add SpacemiT K3 CPU entity associated with the new microarchitecture.
- Define SpacemiT K3 Pico-ITX device entity with SD/SSD and UFS storage variants.

## Summary by Sourcery

Add support for the SpacemiT K3 Pico-ITX device family and associated provisioning workflow and images.

New Features:
- Introduce SpacemiT X100 RISC-V microarchitecture and SpacemiT K3 CPU entities.
- Add SpacemiT K3 Pico-ITX device with SD/SSD and UFS storage variants and corresponding image-combo entities.
- Provide Bianbu Desktop LXQt and Minimal images (UEFI and non-UEFI, SD and UFS) for SpacemiT K3 with appropriate partition maps.
- Implement a SpacemiT K3 fastboot-based device provision strategy plugin.

Enhancements:
- Clarify metadata descriptions for existing SpacemiT K1 UEFI board images.
- Extend i18n message catalog with SpacemiT K3 provisioning messages.