### PR TITLE
board-image/armbian-spacemit-musepipro-xfce: add new package

### DIFF
--- a/entities/image-combo/armbian-spacemit-musepipro-xfce.toml
+++ b/entities/image-combo/armbian-spacemit-musepipro-xfce.toml
@@ -1,0 +1,10 @@
+ruyi-entity = "v0"
+
+related = [
+  "device-variant:spacemit-musepipro@sd"
+]
+unique_among_type_during_traversal = true
+
+[image-combo]
+display_name = "Armbian xfce desktop for SpacemiT Muse Pi Pro"
+package_atoms = ["board-image/armbian-spacemit-musepipro-xfce"]

--- a/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.228.toml
+++ b/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.228.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian xfce desktop 26.8.0-trunk.228 image for SpacemiT Muse Pi Pro"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.8.0-trunk.228"
+
+[[distfiles]]
+name = "Armbian_26.8.0-trunk.228_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz"
+size = 798938364
+urls = [
+  "https://github.com/armbian/os/releases/download/26.8.0-trunk.228/Armbian_26.8.0-trunk.228_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "1905858342aeac18b3079661513fa94611b6cd6e34ec4f17b1d4d0b3f8158f26"
+sha512 = "8c469c8323d63144923eab9176ff7a953768a50d7c18b136725f2e8dec2d59db31494b2807226e7a430db77704c03b778995f87efa7fdb3229736597aa20b223"
+
+[blob]
+distfiles = [
+  "Armbian_26.8.0-trunk.228_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_26.8.0-trunk.228_Musepipro_noble_current_6.18.36_xfce_desktop.img"

--- a/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.232.toml
+++ b/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.232.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian xfce desktop 26.8.0-trunk.232 image for SpacemiT Muse Pi Pro"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.8.0-trunk.232"
+
+[[distfiles]]
+name = "Armbian_26.8.0-trunk.232_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz"
+size = 798471700
+urls = [
+  "https://github.com/armbian/os/releases/download/26.8.0-trunk.232/Armbian_26.8.0-trunk.232_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "86969dd07b346d374c0a49f88e208d71e87696256957248eb021ec37ae9649b9"
+sha512 = "7ac6ee3adcada90edd27795209038c8d0399f6350f6c044433d6b21f2f4e918ebe8af6736730043b5215e7e1dfed7e15f806b2455a7640bdd9ec2b812bbc014f"
+
+[blob]
+distfiles = [
+  "Armbian_26.8.0-trunk.232_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_26.8.0-trunk.232_Musepipro_noble_current_6.18.36_xfce_desktop.img"

--- a/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.237.toml
+++ b/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.237.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian xfce desktop 26.8.0-trunk.237 image for SpacemiT Muse Pi Pro"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.8.0-trunk.237"
+
+[[distfiles]]
+name = "Armbian_26.8.0-trunk.237_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz"
+size = 781255988
+urls = [
+  "https://github.com/armbian/os/releases/download/26.8.0-trunk.237/Armbian_26.8.0-trunk.237_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "593ac1282b66ea2b9345e4543cbddc7c34be520197a35aab8d996c624bc1956d"
+sha512 = "323572ae3efb5889985a42c213b398644cd460fa376a2933427a0a6b32065b85f624c470f4462890faccc4c987aa9f3f0219951aeac66906a8da3c6fd45989c7"
+
+[blob]
+distfiles = [
+  "Armbian_26.8.0-trunk.237_Musepipro_noble_current_6.18.36_xfce_desktop.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_26.8.0-trunk.237_Musepipro_noble_current_6.18.36_xfce_desktop.img"

--- a/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.294.toml
+++ b/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.294.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian xfce desktop 26.8.0-trunk.294 image for SpacemiT Muse Pi Pro"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.8.0-trunk.294"
+
+[[distfiles]]
+name = "Armbian_26.8.0-trunk.294_Musepipro_noble_current_6.18.37_xfce_desktop.img.xz"
+size = 806309608
+urls = [
+  "https://github.com/armbian/os/releases/download/26.8.0-trunk.294/Armbian_26.8.0-trunk.294_Musepipro_noble_current_6.18.37_xfce_desktop.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "60ea31f17397984271e85e032e9f9bc556c3468da44803dcd0077491fa446ca6"
+sha512 = "32a2b3a4f35e469368b661a40fd2d88d58d16bb2a2f0c4f28832076e1e17120955c27a37e763394f2e9abb11a734713fef586c4768f02684bee72a503ce9ed4a"
+
+[blob]
+distfiles = [
+  "Armbian_26.8.0-trunk.294_Musepipro_noble_current_6.18.37_xfce_desktop.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_26.8.0-trunk.294_Musepipro_noble_current_6.18.37_xfce_desktop.img"

--- a/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.303.toml
+++ b/packages/board-image/armbian-spacemit-musepipro-xfce/26.8.0-trunk.303.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "Armbian xfce desktop 26.8.0-trunk.303 image for SpacemiT Muse Pi Pro"
+vendor = { name = "Armbian", eula = "" }
+upstream_version = "26.8.0-trunk.303"
+
+[[distfiles]]
+name = "Armbian_26.8.0-trunk.303_Musepipro_noble_current_6.18.37_xfce_desktop.img.xz"
+size = 810552640
+urls = [
+  "https://github.com/armbian/os/releases/download/26.8.0-trunk.303/Armbian_26.8.0-trunk.303_Musepipro_noble_current_6.18.37_xfce_desktop.img.xz",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "94fa5bb3416e49f350e8a6948578644b7f0cd65f8aab43ea85d9fd29ee8b3fbe"
+sha512 = "a803ae62d3bf63c36774f28c2d8535c305bcc9d0004c0381dbe6ea30e90715be04884ea988336a0dc75b55dca1a1021317d3534a62464249635f9bf2bea25a29"
+
+[blob]
+distfiles = [
+  "Armbian_26.8.0-trunk.303_Musepipro_noble_current_6.18.37_xfce_desktop.img.xz",
+]
+
+[provisionable]
+strategy = "dd-v1"
+
+[provisionable.partition_map]
+disk = "Armbian_26.8.0-trunk.303_Musepipro_noble_current_6.18.37_xfce_desktop.img"


### PR DESCRIPTION
1. 执行`ruyi device provision`指令，并输入y确认
<img width="1262" height="817" alt="image" src="https://github.com/user-attachments/assets/24022e9c-e775-4232-ae37-e2f92ac53de6" />
2. 选择`Spacemit MUSE Pi Pro`这个板子
<img width="1210" height="1888" alt="image" src="https://github.com/user-attachments/assets/5330767c-2325-4373-92d6-eeee9117095a" />
3. 选择变体
<img width="1230" height="301" alt="image" src="https://github.com/user-attachments/assets/c9016973-31eb-43f9-868e-8396e2c4b15c" />
4. 选择配置
<img width="1243" height="412" alt="image" src="https://github.com/user-attachments/assets/89f1a631-ad0a-49d4-b6a0-3d70098459a4" />
5. 输入y
<img width="1263" height="156" alt="image" src="https://github.com/user-attachments/assets/7b1e7855-c26c-48f1-b25e-1bb159de89e3" />
6. 选择软件包
<img width="1262" height="646" alt="image" src="https://github.com/user-attachments/assets/f8469637-8286-4073-9e8e-90cb7665a1e8" />
7. 继续使用这些版本
<img width="1253" height="465" alt="image" src="https://github.com/user-attachments/assets/a3142d78-84f3-4d3f-9ea5-9f73cb618f9e" />
8. 下载
<img width="1255" height="949" alt="image" src="https://github.com/user-attachments/assets/2d9ec76b-435b-4541-be24-19a77a4f1b6f" />
9. 安装完成
<img width="1266" height="148" alt="image" src="https://github.com/user-attachments/assets/6265f6c6-9673-4911-b7bb-99cb6f469481" />
10. 查看是否存在
<img width="1898" height="85" alt="image" src="https://github.com/user-attachments/assets/f7b83ab3-8419-48d3-9581-5fb38cb22550" />


## Summary by Sourcery

Add Armbian XFCE desktop board image packages and image-combo entities for the SpacemiT Muse Pi Pro across multiple upstream versions.

New Features:
- Introduce Armbian XFCE desktop board images for the SpacemiT Muse Pi Pro with multiple 26.8.0 trunk builds.
- Add image-combo entities wiring the new Muse Pi Pro Armbian XFCE images to both eMMC and SD device variants.

## Summary by Sourcery

Add Armbian XFCE desktop board image packages for the SpacemiT Muse Pi Pro and expose them via a new image-combo entity.

New Features:
- Introduce Armbian XFCE desktop board image definitions for the SpacemiT Muse Pi Pro across multiple 26.8.0 trunk upstream versions.
- Add an image-combo entity to make the new Muse Pi Pro Armbian XFCE images available for the SD device variant.