### PR TITLE
board-image/revyos-sipeed-lpi4a: bump to latest version 20260504

### DIFF
--- a/packages/board-image/revyos-sipeed-lpi4a/0.20260504.0.toml
+++ b/packages/board-image/revyos-sipeed-lpi4a/0.20260504.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20260504 image for Sipeed LicheePi 4A"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "boot-lpi4a-20260504_080619.ext4.zst"
+size = 62695800
+urls = [
+  "mirror://revyos/extra/images/lpi4a/20260504/boot-lpi4a-20260504_080619.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "3e113532933790db505c58cc3b485b0aaaa05af2e89a07d1278e9018a22a5b77"
+sha512 = "b3c0e377131a5b1285efc8ca447d0c39a6984e3e0e936870ff5f2949c9afc40eff1d96f91f2763ecdb0fedddc48f0104a606955e719b66a7c83e148f93889b17"
+
+[[distfiles]]
+name = "root-lpi4a-20260504_080619.ext4.zst"
+size = 1382432321
+urls = [
+  "mirror://revyos/extra/images/lpi4a/20260504/root-lpi4a-20260504_080619.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "bb7eefb96c04bab5e86cc5c14787baef4ab3b1018bb21ff4665ed7729f76da0e"
+sha512 = "f97bf67a9da2b333a37133ffc5baa9662c2fc8dae92bce0a8d64b830b7f850793f247132f74aa98aea37ce9b3739b043ec4da0654abe606edcc3e12cbe6b58b0"
+
+[blob]
+distfiles = [
+  "boot-lpi4a-20260504_080619.ext4.zst",
+  "root-lpi4a-20260504_080619.ext4.zst",
+]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[provisionable.partition_map]
+boot = "boot-lpi4a-20260504_080619.ext4"
+root = "root-lpi4a-20260504_080619.ext4"

--- a/packages/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20260504.0.toml
+++ b/packages/board-image/uboot-revyos-sipeed-lpi4a-16g/0.20260504.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (16G RAM) and RevyOS 20260504"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a-16g.bin"
+size = 992168
+urls = [
+  "mirror://revyos/extra/images/lpi4a/20260504/u-boot-with-spl-lpi4a-16g.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "360d5d479a334e35b333a9374ba454195ea0170cde29a303ea81f9359fb49fa3"
+sha512 = "e6ab1ab392034efad8e6c5b047ff07a290d49e20f26dbd652f2c180e4f3b8d129ddca594d7952c4b6a2cd3a9c49956792e0886db0a115bdaed52d1d5063637f0"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-lpi4a-16g.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a-16g.bin"

--- a/packages/board-image/uboot-revyos-sipeed-lpi4a-8g/0.20260504.0.toml
+++ b/packages/board-image/uboot-revyos-sipeed-lpi4a-8g/0.20260504.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for LicheePi 4A (8G RAM) and RevyOS 20260504"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "u-boot-with-spl-lpi4a.bin"
+size = 1031704
+urls = [
+  "mirror://revyos/extra/images/lpi4a/20260504/u-boot-with-spl-lpi4a.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "ced654357317c9c74f1d2cd847ddf119ff332d78c832cd14371b158333b95318"
+sha512 = "87dee9c29b91a689c8b4bf72254c03fe3b0a59b70ccf0ff940766c0fca02fb43b22f1355827c2f3396edb691a69c69bfbfffde3932951529a61656db844fec03"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-lpi4a.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lpi4a.bin"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add packaging metadata for RevyOS 20260504 image for the Sipeed LicheePi 4A board, including boot and root filesystem artifacts