### PR TITLE
board-image/revyos-sipeed-lcon4a: bump to latest version 20260504

### DIFF
--- a/packages/board-image/revyos-sipeed-lcon4a/0.20260504.0.toml
+++ b/packages/board-image/revyos-sipeed-lcon4a/0.20260504.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20260504 image for Sipeed Lichee Console 4A"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "boot-console-20260504_080608.ext4.zst"
+size = 62694588
+urls = [
+  "mirror://revyos/extra/images/lcon4a/20260504/boot-console-20260504_080608.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "597f1f65b76dd30bb54e193536be94caecf75de48968f9a4eecc31d2a20acacb"
+sha512 = "8707bc16c74151d6e350b007ea86f06067d60dcbb61790770081805209b9874a0018bdd5d24bd35e19f63283002932aadde6d95474baaaa83e31c6d2f81bf4d3"
+
+[[distfiles]]
+name = "root-console-20260504_080608.ext4.zst"
+size = 1389824544
+urls = [
+  "mirror://revyos/extra/images/lcon4a/20260504/root-console-20260504_080608.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "234a1a564220242132ebb38a310fa112d7fcd5c8ee191e449fe7cc2ecef0db92"
+sha512 = "41933a97a0dd0e86b0fe8bb0b2d36ee3622e8ec4b8643ec0fade55063cf799b0db6c16a31fc304de8be7adce4b6545efdb009490dbf775eab1b905c3337ca07f"
+
+[blob]
+distfiles = [
+  "boot-console-20260504_080608.ext4.zst",
+  "root-console-20260504_080608.ext4.zst",
+]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[provisionable.partition_map]
+boot = "boot-console-20260504_080608.ext4"
+root = "root-console-20260504_080608.ext4"

--- a/packages/board-image/uboot-revyos-sipeed-lcon4a-16g/0.20260504.0.toml
+++ b/packages/board-image/uboot-revyos-sipeed-lcon4a-16g/0.20260504.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Sipeed Lichee Console 4A (16G RAM) and RevyOS 20260504"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "u-boot-with-spl-lcon4a-16g.bin"
+size = 1031720
+urls = [
+  "mirror://revyos/extra/images/lcon4a/20260504/u-boot-with-spl-lcon4a-16g.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "db43a7d5d468d69a51ec3c903a4a00c233d46be05e5540923555e7ec30306ad3"
+sha512 = "76aac824817c5e4ee8ac6c567b41593d0e0fe1d2655832600d9a593c7597cd08002c7c57373cb6baeda6e1fa9cf4b2197704b3d744d310ec52828e13aed5d006"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-lcon4a-16g.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lcon4a-16g.bin"

--- a/packages/board-image/uboot-revyos-sipeed-lcon4a-8g/0.20260504.0.toml
+++ b/packages/board-image/uboot-revyos-sipeed-lcon4a-8g/0.20260504.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Sipeed Lichee Console 4A (8G RAM) and RevyOS 20260504"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "u-boot-with-spl-lcon4a.bin"
+size = 1031720
+urls = [
+  "mirror://revyos/extra/images/lcon4a/20260504/u-boot-with-spl-lcon4a.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7d910b7096013f75b03a1328a33c7a497ef25bed23bb84b2e3e6fdd3ca837052"
+sha512 = "d2cb8690f4b938d9ab652cf3b5018ebcb511c90f03cedfa95569b18ecd03558d32e31a29f15d5773e6092d822f4534775e4a25e329b8c13185baf81c5e768fbd"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-lcon4a.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-lcon4a.bin"


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a new board-image package version 0.20260504.0 for the RevyOS Sipeed Lichee Console 4A with updated boot and root filesystem images.