### PR TITLE
board-image/revyos-sipeed-laptop4a: bump to latest version 20260504

### DIFF
--- a/packages/board-image/revyos-sipeed-laptop4a/0.20260504.0.toml
+++ b/packages/board-image/revyos-sipeed-laptop4a/0.20260504.0.toml
@@ -1,0 +1,43 @@
+format = "v1"
+
+[metadata]
+desc = "RevyOS 20260504 image for Sipeed Lichee Book 4A"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "boot-laptop-20260504_080647.ext4.zst"
+size = 62698533
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20260504/boot-laptop-20260504_080647.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "5687b527b10db7e15773f7092cf8627c0caa39ff0aa43e55120aa2eeace8c48a"
+sha512 = "00e7ff86fb557452534cf5d83e1900b985033fa172e04f38dedc13e86aa682ea02531f5aa17bc76b952be22c9d3d2af923f4d7f6ae21d608536b2ab444aa89b2"
+
+[[distfiles]]
+name = "root-laptop-20260504_080647.ext4.zst"
+size = 1386198135
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20260504/root-laptop-20260504_080647.ext4.zst",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "7abb6df6a04797eabe8a4c28844ce33335cda4c00a80c795eda78a75b7dfbdc9"
+sha512 = "2225a0da725dad28317e9643e71af89ed43f3e16bd5607f5e196566ce59f0d8857c438a111a294dc64b84d42e1649e7f0ece445e6c7da30f7c4ca4bffef2dbba"
+
+[blob]
+distfiles = [
+  "boot-laptop-20260504_080647.ext4.zst",
+  "root-laptop-20260504_080647.ext4.zst",
+]
+
+[provisionable]
+strategy = "fastboot-v1"
+
+[provisionable.partition_map]
+boot = "boot-laptop-20260504_080647.ext4"
+root = "root-laptop-20260504_080647.ext4"

--- a/packages/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20260504.0.toml
+++ b/packages/board-image/uboot-revyos-sipeed-laptop4a-16g/0.20260504.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (16G RAM) and RevyOS 20260504"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a-16g.bin"
+size = 1031720
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20260504/u-boot-with-spl-laptop4a-16g.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "83ce82811f79e6d2972fb243dc67e0d0f24b4d37fff9430af6e21388ee777c1c"
+sha512 = "bcda2f2d00b1c0af983b0bbfcc68acf3d0928e1704b10df9fd3ed26f882fc68c4fc45122ff2af504b145d8c1431bd30704640b20c2b391c435a280a0a75711ff"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a-16g.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a-16g.bin"

--- a/packages/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20260504.0.toml
+++ b/packages/board-image/uboot-revyos-sipeed-laptop4a-8g/0.20260504.0.toml
@@ -1,0 +1,29 @@
+format = "v1"
+
+[metadata]
+desc = "U-Boot image for Lichee Book 4A (8G RAM) and RevyOS 20260504"
+vendor = { name = "PLCT", eula = "" }
+upstream_version = "20260504"
+
+[[distfiles]]
+name = "u-boot-with-spl-laptop4a.bin"
+size = 1031720
+urls = [
+  "mirror://revyos/extra/images/laptop4a/20260504/u-boot-with-spl-laptop4a.bin",
+]
+restrict = ["mirror"]
+
+[distfiles.checksums]
+sha256 = "28b4aa473c834ec76dd384aca4a22d8195dc9869b239b0f4ded2571438caa9ae"
+sha512 = "4d706e938e41375aa11c473026d03302702802c8ccfd311abf6da188a341aa0f99fe445d6cf750d87e5326255c07a8911143eea369be6007eb1e7774f8a9822e"
+
+[blob]
+distfiles = [
+  "u-boot-with-spl-laptop4a.bin",
+]
+
+[provisionable]
+strategy = "fastboot-v1(lpi4a-uboot)"
+
+[provisionable.partition_map]
+uboot = "u-boot-with-spl-laptop4a.bin"


### PR DESCRIPTION
## Summary by Sourcery

Add a new RevyOS board image definition for the Sipeed Lichee Book 4A for the 20260504 release.

New Features:
- Introduce a 20260504 RevyOS image package for the Sipeed Lichee Book 4A with associated boot and root filesystem artifacts.

Enhancements:
- Define fastboot-based provisioning and partition mapping for the new Sipeed Lichee Book 4A image.